### PR TITLE
Use Options in local.toml files

### DIFF
--- a/cmd/vulcan-aws-trusted-advisor/local.toml
+++ b/cmd/vulcan-aws-trusted-advisor/local.toml
@@ -1,3 +1,3 @@
 [Check]
 Target = "arn:aws:iam::123456789012:root"
-Opts = '{"vulcan_assume_role_url":"http://localhost:8080/assume","role":"SecurityAuditRole", "refresh_timeout": 5}'
+Options = '{"vulcan_assume_role_url":"http://localhost:8080/assume","role":"SecurityAuditRole", "refresh_timeout": 5}'

--- a/cmd/vulcan-dkim/local.toml
+++ b/cmd/vulcan-dkim/local.toml
@@ -2,4 +2,4 @@
 LogLevel = "debug"
 [Check]
 Target = "example.com"
-Opts = "{\"selectors\":[\"default\"]}"
+Options = "{\"selectors\":[\"default\"]}"

--- a/cmd/vulcan-docker-image/local.toml
+++ b/cmd/vulcan-docker-image/local.toml
@@ -3,4 +3,4 @@ Target = "registry-1.docker.io/library/postgres:9.6"
 # example targets:
 # registry-1.docker.io/library/postgres:9.6
 # Port Authority : https://github.com/target/portauthority
-Opts = '{"portauthority_url":"https://example.com/v1/images"}'
+Options = '{"portauthority_url":"https://example.com/v1/images"}'

--- a/cmd/vulcan-exposed-http-endpoint/local.toml
+++ b/cmd/vulcan-exposed-http-endpoint/local.toml
@@ -2,23 +2,23 @@
 LogLevel = "debug"
 [Check]
 Target = "https://example.com"
-Opts = "{\"paths\":[{\"path\":\"/\", \"reg_exp\": \"(?s)Transfer.*Alt\"}]}"
+Options = "{\"paths\":[{\"path\":\"/\", \"reg_exp\": \"(?s)Transfer.*Alt\"}]}"
 
 # Other examples
 
 # This example will trigger the vuln:
 # Target="https://www.google.com"
-# Opts = "{\"paths\":[{\"path\":\"/\", \"reg_exp\": \".*www.google.com.*\"}]}"
+# Options = "{\"paths\":[{\"path\":\"/\", \"reg_exp\": \".*www.google.com.*\"}]}"
 
 
 # This example will not trigger the vuln
 # Target="https://www.google.com"
-# Opts = "{\"paths\":[{\"path\":\"/\", \"status\": 400]}"
+# Options = "{\"paths\":[{\"path\":\"/\", \"status\": 400]}"
 
 # This example will trigger the vuln
 # Target="https://www.google.com"
-# Opts = "{\"paths\":[{\"path\":\"/\"}]}"
+# Options = "{\"paths\":[{\"path\":\"/\"}]}"
 
 # This example will trigger the vuln
 # Target="https://www.google.com"
-# Opts = "{\"paths\":[{\"path\":\"/\", \"status\": 200}]}"
+# Options = "{\"paths\":[{\"path\":\"/\", \"status\": 200}]}"

--- a/cmd/vulcan-exposed-memcached/local.toml
+++ b/cmd/vulcan-exposed-memcached/local.toml
@@ -1,5 +1,5 @@
 [Check]
 Target = "localhost"
-Opts = '{"port":11211}'
+Options = '{"port":11211}'
 [Log]
 LogLevel = "DEBUG"

--- a/cmd/vulcan-exposed-services/local.toml
+++ b/cmd/vulcan-exposed-services/local.toml
@@ -2,4 +2,4 @@
 LogLevel = "debug"
 [Check]
 Target = "localhost"
-Opts = '{"whitelisted_tcp_ports": [], "whitelisted_udp_ports": []}'
+Options = '{"whitelisted_tcp_ports": [], "whitelisted_udp_ports": []}'

--- a/cmd/vulcan-exposed-ssh/local.toml
+++ b/cmd/vulcan-exposed-ssh/local.toml
@@ -2,4 +2,4 @@
 LogLevel = "debug"
 [Check]
 Target = "example.com"
-Opts = "{\"ports\":[\"22\"], \"allowed\": true}"
+Options = "{\"ports\":[\"22\"], \"allowed\": true}"

--- a/cmd/vulcan-host-discovery/local.toml
+++ b/cmd/vulcan-host-discovery/local.toml
@@ -2,4 +2,4 @@
 LogLevel = "debug"
 [Check]
 Target = "localhost"
-Opts = '{"timing": 3, "known_hosts_list_url": ""}'
+Options = '{"timing": 3, "known_hosts_list_url": ""}'

--- a/cmd/vulcan-masscan/local.toml
+++ b/cmd/vulcan-masscan/local.toml
@@ -2,4 +2,4 @@
 LogLevel = "DEBUG"
 [Check]
 Target = "1.1.1.1/32"
-Opts = '{"port_range":[{"start": 80, "stop": 80}]}'
+Options = '{"port_range":[{"start": 80, "stop": 80}]}'

--- a/cmd/vulcan-nessus/local.toml
+++ b/cmd/vulcan-nessus/local.toml
@@ -1,3 +1,3 @@
 [Check]
 Target = "example.com"
-Opts = "{\"debug\":true,\"policy_id\":9,\"polling_interval\":30,\"basic_auth\":false}" #full-scan
+Options = "{\"debug\":true,\"policy_id\":9,\"polling_interval\":30,\"basic_auth\":false}" #full-scan

--- a/cmd/vulcan-results-load-test/local.toml
+++ b/cmd/vulcan-results-load-test/local.toml
@@ -1,2 +1,2 @@
 [Check]
-Opts = "{\"raw_size\":2, \"report_size\":2}"
+Options = "{\"raw_size\":2, \"report_size\":2}"

--- a/cmd/vulcan-sleep/local.toml
+++ b/cmd/vulcan-sleep/local.toml
@@ -1,2 +1,2 @@
 [Check]
-Opts = "{\"sleep_time\":1}"
+Options = "{\"sleep_time\":1}"

--- a/cmd/vulcan-zap/local.toml
+++ b/cmd/vulcan-zap/local.toml
@@ -1,3 +1,3 @@
 [Check]
 Target = "example.com"
-Opts = "{\"depth\":2, \"active\":true}"
+Options = "{\"depth\":2, \"active\":true}"


### PR DESCRIPTION
This PR modifies all the local.toml using the field with name "Opt"s with the name "Options" as is defined in the new version of the SDK (see https://github.com/adevinta/vulcan-check-sdk/pull/2)
Note that this PR by its own does not adapt completely the checks to the new version of the SDK.
To do so, we will also need to update the version of the sdk defined in the go.mod file after that new version is in master. 