### PR TITLE
Remove QueueName from manifest

### DIFF
--- a/cmd/vulcan-nessus/manifest.toml
+++ b/cmd/vulcan-nessus/manifest.toml
@@ -1,6 +1,5 @@
 Description = "Runs a Nessus scan"
 Timeout = 28800 # 8 hour. Expressed in seconds as an integer.
-QueueName = "vulcanNessusQueue"
 AssetTypes = ["Hostname", "IP"]
 RequiredVars = [
   "NESSUS_ENDPOINT",


### PR DESCRIPTION
Now it is being set directly in the vulcan-persistence config files. Check https://github.com/adevinta/vulcan-persistence/pull/6