### PR TITLE
Fix vulcan-gozuul to scan Hostnames and IPs

### DIFF
--- a/cmd/vulcan-gozuul/manifest.toml
+++ b/cmd/vulcan-gozuul/manifest.toml
@@ -1,2 +1,2 @@
 Description = "Checks if an asset is vulnerable to Remote Code Execution as specified in nflx-2016-003"
-AssetTypes = ["Hostname", "IP"]
+AssetTypes = ["Hostname", "IP", "WebAddress"]

--- a/cmd/vulcan-gozuul/manifest.toml
+++ b/cmd/vulcan-gozuul/manifest.toml
@@ -1,2 +1,3 @@
 Description = "Checks if an asset is vulnerable to Remote Code Execution as specified in nflx-2016-003"
 AssetTypes = ["Hostname", "IP", "WebAddress"]
+Options = '{"ports" : [80, 443, 8080]}'


### PR DESCRIPTION
Check was failing for `Hostname` and `IP` targets because the `gozuul.PasiveScan` function expects a URL (e.g. "www.adevinta.com").

Now the check can scan `WebAddress`, `Hostname`, and `IP`.

For the latest two, it converts the target to a URL using schemes and ports provided by `Options`. If no options are provided, the schemes used are `http` and `https`, while the ports are `80` and `443`.

Before calling the `gozuul` library, it checks that the URLs are reachable, otherwise it skips the call to the lib.

Test env: 3 zuul instances running in ports 8080, 8081 and 8082 (vulnerable, not vulnerable and vulnerable respectively).

```
$ vulcan-gozuul -t
WARN[2019-12-05 17:30:06] Building test agent listening on URL          URL="127.0.0.1:51497" check=vulcan-gozuul checkID= checkTypeName= checkTypeVersion= component=check opts="{\"ports\" : [8080, 8081, 8082]}" target=localhost
INFO[2019-12-05 17:30:06] Check start                                   check=vulcan-gozuul checkID= checkTypeName= checkTypeVersion= component=check opts="{\"ports\" : [8080, 8081, 8082]}" target=localhost
INFO[2019-12-05 17:30:06] Check finished                                check=vulcan-gozuul checkID= checkTypeName= checkTypeVersion= component=check fields.time=68.112316ms opts="{\"ports\" : [8080, 8081, 8082]}" state="&{FINISHED 1 {{testCheckID   FINISHED localhost {\"ports\" : [8080, 8081, 8082]}  2019-12-05 17:30:06.830208 +0100 CET m=+0.004366561 2019-12-05 17:30:06.898628 +0100 CET m=+0.072788308} {[{ Remote Code Exeucition in Zuul 8.9 434 Zuul was configured with zuul.filter.admin.enabled to True, which can be used to upload filters via the default application port which may result in Remote Code Execution (RCE).  Allows remote attackers to execute code in the server via uploading a malicious filter. [Ensure the property ZUUL_FILTER_ADMIN_ENABLED is set to False.] [https://github.com/Netflix/security-bulletins/blob/master/advisories/nflx-2016-003.md] [{Network Resources [URL] [map[URL:http://localhost:8080] map[URL:http://localhost:8082]]}] [] []}] []   false}}}" target=localhost
agent.State{
    Status:   "FINISHED",
    Progress: 1,
    Report:   report.Report{
        CheckData: report.CheckData{
            CheckID:          "testCheckID",
            ChecktypeName:    "",
            ChecktypeVersion: "",
            Status:           "FINISHED",
            Target:           "localhost",
            Options:          "{\"ports\" : [8080, 8081, 8082]}",
            Tag:              "",
            StartTime:        time.Time{},
            EndTime:          time.Time{},
        },
        ResultData: report.ResultData{
            Vulnerabilities: {
                {
                    ID:              "",
                    Summary:         "Remote Code Exeucition in Zuul",
                    Score:           8.899999618530273,
                    CWEID:           0x1b2,
                    Description:     "Zuul was configured with zuul.filter.admin.enabled to True, which can be used to upload filters via the default application port which may result in Remote Code Execution (RCE).",
                    Details:         "",
                    ImpactDetails:   "Allows remote attackers to execute code in the server via uploading a malicious filter.",
                    Recommendations: {"Ensure the property ZUUL_FILTER_ADMIN_ENABLED is set to False."},
                    References:      {"https://github.com/Netflix/security-bulletins/blob/master/advisories/nflx-2016-003.md"},
                    Resources:       {
                        {
                            Name:   "Network Resources",
                            Header: {"URL"},
                            Rows:   {
                                {"URL":"http://localhost:8080"},
                                {"URL":"http://localhost:8082"},
                            },
                        },
                    },
                    Attachments:     nil,
                    Vulnerabilities: nil,
                },
            },
            Data:          nil,
            Notes:         "",
            Error:         "",
            NotApplicable: false,
        },
    },
}
```