### PR TITLE
Add dependabot configuration

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,10 @@
+version: 1
+update_configs:
+  - package_manager: "go:modules"
+    directory: "/"
+    update_schedule: "daily"
+    allowed_updates:
+      - match:
+          update_type: "security"
+      - match:
+          dependency_name: "*adevinta*"


### PR DESCRIPTION
Configuration is set to always upgrade dependencies due to security issues, and always upgrade adevinta dependencies.

**NOTE:** Should we include Seekret as matching option also?