### PR TITLE
Set default Seekret clone depth to 1

### DIFF
--- a/cmd/vulcan-seekret/main.go
+++ b/cmd/vulcan-seekret/main.go
@@ -21,8 +21,8 @@ import (
 	http "gopkg.in/src-d/go-git.v4/plumbing/transport/http"
 )
 
-type opt struct {
-	Depth string `json:"depth"`
+type options struct {
+	Depth int `json:"depth"`
 }
 
 var (

--- a/cmd/vulcan-seekret/main.go
+++ b/cmd/vulcan-seekret/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -19,6 +20,10 @@ import (
 	git "gopkg.in/src-d/go-git.v4"
 	http "gopkg.in/src-d/go-git.v4/plumbing/transport/http"
 )
+
+type opt struct {
+	Depth string `json:"depth"`
+}
 
 var (
 	checkName    = "vulcan-seekret"
@@ -60,6 +65,14 @@ func main() {
 			return errors.New("check target missing")
 		}
 
+		var opt options
+		opt.Depth = 1
+		if optJSON != "" {
+			if err := json.Unmarshal([]byte(optJSON), &opt); err != nil {
+				return err
+			}
+		}
+
 		// We check if the target is not the public Github.
 		targetURL, err := url.Parse(target)
 		if err != nil {
@@ -80,8 +93,9 @@ func main() {
 		}
 
 		_, err = git.PlainClone(repoPath, false, &git.CloneOptions{
-			URL:  target,
-			Auth: auth,
+			URL:   target,
+			Auth:  auth,
+			Depth: opt.Depth,
 		})
 		if err != nil {
 			return err

--- a/cmd/vulcan-seekret/manifest.toml
+++ b/cmd/vulcan-seekret/manifest.toml
@@ -2,3 +2,4 @@ Description = "Finds leaked secrets in a Git repository using Seekret"
 Timeout = 600
 AssetTypes = ["GitRepository"]
 RequiredVars = ["GITHUB_ENTERPRISE_TOKEN"]
+Options = '{"depth": 1}'


### PR DESCRIPTION
Prevent overloading Github servers **by default** by only cloning the last commit if the depth option is not specified.