### PR TITLE
Remove /dump from vulcan-exposed-http-resources

### DIFF
--- a/cmd/vulcan-exposed-http-resources/resources.yaml
+++ b/cmd/vulcan-exposed-http-resources/resources.yaml
@@ -178,7 +178,6 @@
   description: Potentially exposed source backups.
 
 - paths:
-  - "dump"
   - "dump.7z"
   - "dump.log"
   - "dump.old"


### PR DESCRIPTION
The path "/dump" has triggered a false positive for us. Since there is no "grep" (hard to do with so many different extensions, many of them compressed files), I think it may make sense to remove this specific test to avoid false positives in the future.