### PR TITLE
Vulcan-vulners:Unique vulnerability per host and product found in a target

### DIFF
--- a/cmd/vulcan-vulners/main.go
+++ b/cmd/vulcan-vulners/main.go
@@ -110,7 +110,7 @@ type vulnersFinding struct {
 	Resources report.ResourcesGroup
 }
 
-// buildVulnersFinding builds a vulner Finding querying the vulners.com API. The
+// buildVulnersFinding builds a vulners finding querying the vulners.com API. The
 // resources of the finding contain the CVE'S found for the software component.
 // The Score of the finding contains the highest score found in the all the
 // CVE's.

--- a/cmd/vulcan-vulners/main.go
+++ b/cmd/vulcan-vulners/main.go
@@ -114,7 +114,7 @@ type vulnersFinding struct {
 // resources of the finding contain the CVE'S found for the software component.
 // The Score of the finding contains the highest score found in the all the
 // CVE's.
-func buildVulnersFinding(p, s, v, t string) (*vulnersFinding, error) {
+func buildVulnersFinding(s, v, t string) (*vulnersFinding, error) {
 	client := &http.Client{}
 	endpoint := apiEndpoint(s, v, t)
 	logger.Debugf("Using %s as endpoint", endpoint)
@@ -227,11 +227,11 @@ func findingByCPE(CPE string) (*vulnersFinding, error) {
 		return nil, nil
 	}
 
-	return buildVulnersFinding(parts[3], CPE, parts[4], "cpe")
+	return buildVulnersFinding(CPE, parts[4], "cpe")
 }
 
 func findingByProdVers(s, v, t string) (*vulnersFinding, error) {
-	return buildVulnersFinding(s, s, v, t)
+	return buildVulnersFinding(s, v, t)
 }
 
 func analyzeReport(target string, nmapReport *gonmap.NmapRun) ([]report.Vulnerability, error) {

--- a/cmd/vulcan-vulners/main.go
+++ b/cmd/vulcan-vulners/main.go
@@ -105,8 +105,17 @@ func severity(score float32) string {
 	}
 }
 
-// vulnerabilities retrieves the vulnerabilities affecting a software component from the vulners.com API.
-func vulnerabilities(p, s, v, t string) (*report.Vulnerability, error) {
+type vulnerFinding struct {
+	Score    float32
+	Resource report.ResourcesGroup
+}
+
+// buildVulnerFinding builds a vulner Finding querying the vulners.com API. The
+// resources of the finding contain the CVE'S found for the software component.
+// The Score of the finding contains the highest score found in the all the
+// CVE's.
+func buildVulnerFinding(p, s, v, t string) (*vulnerFinding, error) {
+
 	client := &http.Client{}
 
 	endpoint := apiEndpoint(s, v, t)
@@ -145,8 +154,6 @@ func vulnerabilities(p, s, v, t string) (*report.Vulnerability, error) {
 		return nil, nil
 	}
 
-	vuln := vulnersVuln
-
 	gr := report.ResourcesGroup{
 		Name: "Findings",
 		Header: []string{
@@ -159,6 +166,7 @@ func vulnerabilities(p, s, v, t string) (*report.Vulnerability, error) {
 
 	add := false
 	var rows []map[string]string
+	var score float32
 	for _, e := range b.Data.Search {
 		// NOTE (julianvilas): for now support just the CVE type. But would be good
 		// to evaluate other types.
@@ -168,18 +176,19 @@ func vulnerabilities(p, s, v, t string) (*report.Vulnerability, error) {
 
 		add = true
 
-		finding := map[string]string{
+		r := map[string]string{
 			"CVE":      e.Source.ID,
 			"Severity": severity(float32(e.Source.CVSS.Score)),
 			"Score":    fmt.Sprintf("%.2f", e.Source.CVSS.Score),
 			"Link":     e.Source.Href,
 		}
-		rows = append(rows, finding)
+		rows = append(rows, r)
 
-		logger.WithFields(logrus.Fields{"resource": finding}).Debug("Resource added")
+		logger.WithFields(logrus.Fields{"resource": r}).Debug("Resource added")
 
-		if float32(e.Source.CVSS.Score) > vuln.Score {
-			vuln.Score = float32(e.Source.CVSS.Score)
+		// score contains the max score found in all the CVE's of the finding.
+		if float32(e.Source.CVSS.Score) > score {
+			score = float32(e.Source.CVSS.Score)
 		}
 	}
 
@@ -198,13 +207,16 @@ func vulnerabilities(p, s, v, t string) (*report.Vulnerability, error) {
 	})
 	gr.Rows = rows
 
-	vuln.Resources = append(vuln.Resources, gr)
-	logger.WithFields(logrus.Fields{"vulnerability": vuln}).Debug("Vulnerability added")
+	f := vulnerFinding{
+		Resource: gr,
+		Score:    score,
+	}
+	logger.WithFields(logrus.Fields{"vulnerFinfingAdded": f}).Debug("vulner finding added")
 
-	return &vuln, nil
+	return &f, nil
 }
 
-func vulnerabilitiesByCPE(CPE string) (*report.Vulnerability, error) {
+func findingByCPE(CPE string) (*vulnerFinding, error) {
 	if !cpeRegex.MatchString(CPE) {
 		return nil, fmt.Errorf("the CPE %s doesn't match the regex %s", CPE, cpeRegex)
 	}
@@ -217,15 +229,21 @@ func vulnerabilitiesByCPE(CPE string) (*report.Vulnerability, error) {
 		return nil, nil
 	}
 
-	return vulnerabilities(parts[3], CPE, parts[4], "cpe")
+	return buildVulnerFinding(parts[3], CPE, parts[4], "cpe")
 }
 
-func vulnerabilitiesByProdVers(s, v, t string) (*report.Vulnerability, error) {
-	return vulnerabilities(s, s, v, t)
+func findingByProdVers(s, v, t string) (*vulnerFinding, error) {
+	return buildVulnerFinding(s, s, v, t)
 }
 
 func analyzeReport(target string, nmapReport *gonmap.NmapRun) ([]report.Vulnerability, error) {
-	var vulns []report.Vulnerability
+	type vulnData struct {
+		Vuln     report.Vulnerability
+		CPEs     map[string]struct{}
+		Products map[string]struct{}
+	}
+	uniqueVulns := map[string]vulnData{}
+
 	for _, host := range nmapReport.Hosts {
 		for _, port := range host.Ports {
 			logger.Debugf("Port detected: %d/%s", port.PortId, port.Protocol)
@@ -234,19 +252,35 @@ func analyzeReport(target string, nmapReport *gonmap.NmapRun) ([]report.Vulnerab
 			for _, cpe := range port.Service.CPEs {
 				logger.Debugf("CPE found: %v", cpe)
 				done = true
-
-				v, err := vulnerabilitiesByCPE(string(cpe))
+				f, err := findingByCPE(string(cpe))
 				if err != nil {
 					return nil, err
 				}
-
-				if v != nil {
-					v.Summary = fmt.Sprintf(v.Summary, port.Service.Product)
-					v.Description = fmt.Sprintf(v.Description, port.Service.Product)
-					v.Details = fmt.Sprintf("Found at port %d/%s", port.PortId, port.Protocol)
-
-					vulns = append(vulns, *v)
+				if f == nil {
+					continue
 				}
+				summary := fmt.Sprintf(vulnersVuln.Summary, port.Service.Product)
+				v, ok := uniqueVulns[summary]
+				if !ok {
+					v.Vuln = report.Vulnerability{
+						Summary:         summary,
+						Description:     fmt.Sprintf(vulnersVuln.Description, port.Service.Product),
+						Recommendations: vulnersVuln.Recommendations,
+					}
+					v.CPEs = map[string]struct{}{}
+					uniqueVulns[summary] = v
+				}
+				if _, ok := v.CPEs[string(cpe)]; !ok {
+					v.CPEs[string(cpe)] = struct{}{}
+					v.Vuln.Resources = append(v.Vuln.Resources, f.Resource)
+					uniqueVulns[summary] = v
+					if f.Score > v.Vuln.Score {
+						v.Vuln.Score = f.Score
+					}
+				}
+				v.Vuln.Details = fmt.Sprintf("%sFound in %s at port %d/%s\n", v.Vuln.Details, host.Hostnames[0].Name, port.PortId, port.Protocol)
+
+				uniqueVulns[summary] = v
 			}
 			if done {
 				continue
@@ -259,20 +293,39 @@ func analyzeReport(target string, nmapReport *gonmap.NmapRun) ([]report.Vulnerab
 				continue
 			}
 
-			v, err := vulnerabilitiesByProdVers(port.Service.Product, port.Service.Version, "software")
+			f, err := findingByProdVers(port.Service.Product, port.Service.Version, "software")
 			if err != nil {
 				return nil, err
 			}
-			if v != nil {
-				v.Summary = fmt.Sprintf(v.Summary, port.Service.Product)
-				v.Description = fmt.Sprintf(v.Description, port.Service.Product)
-				v.Details = fmt.Sprintf("Found at %d", port.PortId)
-
-				vulns = append(vulns, *v)
+			summary := fmt.Sprintf(vulnersVuln.Summary, port.Service.Product)
+			v, ok := uniqueVulns[summary]
+			if !ok {
+				v.Vuln = report.Vulnerability{
+					Summary:         summary,
+					Description:     fmt.Sprintf(vulnersVuln.Description, port.Service.Product),
+					Score:           f.Score,
+					Recommendations: vulnersVuln.Recommendations,
+				}
+				v.CPEs = map[string]struct{}{}
+				uniqueVulns[summary] = v
 			}
+			productID := port.Service.Product + port.Service.Version
+			if _, ok := v.Products[productID]; !ok {
+				v.CPEs[productID] = struct{}{}
+				v.Vuln.Resources = append(v.Vuln.Resources, f.Resource)
+				uniqueVulns[summary] = v
+				if f.Score > v.Vuln.Score {
+					v.Vuln.Score = f.Score
+				}
+			}
+			v.Vuln.Details = fmt.Sprintf("%sFound in %s at port %d/%s\n", v.Vuln.Details, host.Hostnames[0].Name, port.PortId, port.Protocol)
+			uniqueVulns[summary] = v
 		}
 	}
-
+	var vulns []report.Vulnerability
+	for _, v := range uniqueVulns {
+		vulns = append(vulns, v.Vuln)
+	}
 	return vulns, nil
 }
 

--- a/cmd/vulcan-vulners/main.go
+++ b/cmd/vulcan-vulners/main.go
@@ -110,11 +110,11 @@ type vulnersFinding struct {
 	Resources report.ResourcesGroup
 }
 
-// buildVulnerFinding builds a vulner Finding querying the vulners.com API. The
+// buildVulnersFinding builds a vulner Finding querying the vulners.com API. The
 // resources of the finding contain the CVE'S found for the software component.
 // The Score of the finding contains the highest score found in the all the
 // CVE's.
-func buildVulnerFinding(p, s, v, t string) (*vulnersFinding, error) {
+func buildVulnersFinding(p, s, v, t string) (*vulnersFinding, error) {
 	client := &http.Client{}
 	endpoint := apiEndpoint(s, v, t)
 	logger.Debugf("Using %s as endpoint", endpoint)
@@ -209,7 +209,7 @@ func buildVulnerFinding(p, s, v, t string) (*vulnersFinding, error) {
 		Resources: gr,
 		Score:     score,
 	}
-	logger.WithFields(logrus.Fields{"vulnerFindingAdded": f}).Debug("vulner finding added")
+	logger.WithFields(logrus.Fields{"vulnersFindingAdded": f}).Debug("vulners finding added")
 
 	return &f, nil
 }
@@ -227,11 +227,11 @@ func findingByCPE(CPE string) (*vulnersFinding, error) {
 		return nil, nil
 	}
 
-	return buildVulnerFinding(parts[3], CPE, parts[4], "cpe")
+	return buildVulnersFinding(parts[3], CPE, parts[4], "cpe")
 }
 
 func findingByProdVers(s, v, t string) (*vulnersFinding, error) {
-	return buildVulnerFinding(s, s, v, t)
+	return buildVulnersFinding(s, s, v, t)
 }
 
 func analyzeReport(target string, nmapReport *gonmap.NmapRun) ([]report.Vulnerability, error) {


### PR DESCRIPTION
This PR modifies the vulcan-vulnercheck so, now it creates a unique vulnerability when the same finding is found in different ports of the target. The ports where that finding has been found are added to the Details field of the vulnerability. The list of CVE's found for the same finding in different ports should be the same, but in any case the check dedupes them, so only unique CVE's are added to the resources table.
This is an example of the report generates by the check, when the finding "Multiple vulnerabilities in Apache httpd"  is found in two ports of the target (look at the details section):
```
agent.State{
    Status:   "FINISHED",
    Progress: 1,
    Report:   report.Report{
        CheckData: report.CheckData{
            CheckID:          "testCheckID",
            ChecktypeName:    "",
            ChecktypeVersion: "",
            Status:           "FINISHED",
            Target:           "docker.for.mac.localhost",
            Options:          "",
            Tag:              "",
            StartTime:        time.Time{},
            EndTime:          time.Time{},
        },
        ResultData: report.ResultData{
            Vulnerabilities: {
                {
                    ID:              "",
                    Summary:         "Multiple vulnerabilities in Apache httpd",
                    Score:           6.800000190734863,
                    CWEID:           0x0,
                    Description:     "One or more vulnerabilities were detected in Apache httpd.",
                    Details:         "Found in docker.for.mac.localhost at port 7070/tcp\nFound in docker.for.mac.localhost at port 9090/tcp\n",
                    ImpactDetails:   "",
                    Recommendations: {"If possible, restrict network access to the service.", "Check if the service has available security updates and apply them.", "When in doubt, check the resources linked below."},
                    References:      nil,
                    Resources:       {
                        {
                            Name:   "Findings",
                            Header: {"CVE", "Severity", "Score", "Link"},
                            Rows:   {
                                {"Severity":"Medium", "CVE":"CVE-2018-1312", "Link":"https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2018-1312", "Score":"6.80"},
                                {"CVE":"CVE-2016-8612", "Link":"https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-8612", "Score":"3.30", "Severity":"Low"},
                            },
                        },
                    },
                    Attachments:     nil,
                    Vulnerabilities: nil,
                },
            },
            Data:          nil,
            Notes:         "",
            Error:         "",
            NotApplicable: false,
        },
    },
}
``` 

In order to simulate test this locally you can spawn two vulnerable Apache using docker by executing:
```
docker run --rm -dit --name my-apache-1 -p 9090:80 -v /tmp:/usr/local/apache2/htdocs/ httpd:2.2
docker run --rm -dit --name my-apache-2 -p 3030:80 -v /tmp:/usr/local/apache2/htdocs/ httpd:2.2
``` 
Then add the a file local.toml in vulcan-checks/cmd/vulcan-vulners/local.toml
with the following contents (only if you are using macos):
```
[Check]
Target = "docker.for.mac.localhost"
[Log]
LogLevel = "DEBUG"
```
And finally executing at the root of the repo the following:
``` vulcan-build-images -r  cmd/vulcan-vulners```