### PR TITLE
Filter non-printable characters

### DIFF
--- a/cmd/vulcan-seekret/main.go
+++ b/cmd/vulcan-seekret/main.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"unicode"
 
 	check "github.com/adevinta/vulcan-check-sdk"
 	"github.com/adevinta/vulcan-check-sdk/state"
@@ -154,9 +155,20 @@ func main() {
 					continue
 				}
 
-				lineSummary := secret.Line
-				if len(lineSummary) > 30 {
-					lineSummary = lineSummary[0:29] + "..."
+				// Truncate line to 30 characters and replace non-ASCII characters with "?".
+				// This is done to avoid both processing and presentation issues.
+				lineSummary := ""
+				for i := range secret.Line {
+					if i >= 30 {
+						lineSummary += "..."
+						break
+					}
+
+					if secret.Line[i] > unicode.MaxASCII {
+						lineSummary += "?"
+					} else {
+						lineSummary += string(secret.Line[i])
+					}
 				}
 
 				ruleScore := float32(report.SeverityThresholdHigh)

--- a/cmd/vulcan-seekret/main.go
+++ b/cmd/vulcan-seekret/main.go
@@ -155,7 +155,7 @@ func main() {
 					continue
 				}
 
-				// Truncate line to 30 characters and replace non-ASCII characters with "?".
+				// Truncate line to 30 characters and replace non-printable characters with "?".
 				// This is done to avoid both processing and presentation issues.
 				lineSummary := ""
 				for i := range secret.Line {
@@ -164,10 +164,11 @@ func main() {
 						break
 					}
 
-					if secret.Line[i] > unicode.MaxASCII {
+					char := rune(secret.Line[i])
+					if char > unicode.MaxASCII || !unicode.IsPrint(char) {
 						lineSummary += "?"
 					} else {
-						lineSummary += string(secret.Line[i])
+						lineSummary += string(char)
 					}
 				}
 


### PR DESCRIPTION
Filter non-ASCII and non-printable characters and replace them with `?`. The goal is to avoid mojibake and inconsistent shortening in the UI while also to prevent future encoding and decoding errors along the way.

Instead of this:

![image](https://user-images.githubusercontent.com/7050335/87017110-da1dd280-c1cf-11ea-9dc5-c4315b12d438.png)

We print this:

![image](https://user-images.githubusercontent.com/7050335/87017146-e6a22b00-c1cf-11ea-94f7-d6094cf3df40.png)
