### PR TITLE
Remove dump/ from vulcan-exposed-http-resources

### DIFF
--- a/cmd/vulcan-exposed-http-resources/resources.yaml
+++ b/cmd/vulcan-exposed-http-resources/resources.yaml
@@ -191,7 +191,6 @@
   - "dump.tar.gz"
   - "dump.tgz"
   - "dump.zip"
-  - "dump/"
   - "database.sql"
   - "1.sql"
   - "backup.sql"


### PR DESCRIPTION
'dump' was recently removed (https://github.com/adevinta/vulcan-checks/pull/62), this removes 'dump/' as well.