### PR TITLE
vulcan-prowler: select group of controls according to security-level

### DIFF
--- a/cmd/vulcan-prowler/local.toml.example
+++ b/cmd/vulcan-prowler/local.toml.example
@@ -1,6 +1,6 @@
 [Check]
 Target = "arn:aws:iam::123456789012:root"
-Options = '{"region":"eu-west-1","groups":["cislevel1"],"sessionDuration":3600}'
+Options = '{"region":"eu-west-1","groups":["cislevel1"],"session_duration":3600}'
 [RequiredVars]
 VULCAN_ASSUME_ROLE_ENDPOINT = "http://localhost:8080/assume"
 ROLE_NAME = "SecurityAuditRole"

--- a/cmd/vulcan-prowler/main.go
+++ b/cmd/vulcan-prowler/main.go
@@ -45,7 +45,7 @@ var (
 	CISCompliance = report.Vulnerability{
 		Summary: "Compliance With CIS AWS Foundations Benchmark (BETA)",
 		Description: `<p>
-			The check did not received the security classification level
+			The check did not receive the security classification
 			of the AWS account so the benchmark has been executed against the
 			CIS Level 2.
 			The CIS AWS Foundations Benchmark provides prescriptive
@@ -55,8 +55,8 @@ var (
 			CloudTrail, CloudWatch, SNS, S3 and VPC (Default).
 		</p>
 		<p>
-			The provided recommendations are provided as a result of controls included in
-			the CIS Level 2.
+			Recommendations are provided in order to comply with all the controls required 
+			by the CIS Level 2.
 		</p>
 		<p>
 			Check the Details and Resources sections to know the compliance status
@@ -84,8 +84,8 @@ var (
 			CloudTrail, CloudWatch, SNS, S3 and VPC (Default).
 		</p>
 		<p>
-			The provided recommendations are provided as a result controls included in
-			the CIS Level 1.
+			Recommendations are provided in order to comply with all the controls required 
+			by the CIS Level 1.
 		</p>
 		<p>
 			Check the Details and Resources sections to know the compliance status
@@ -114,8 +114,8 @@ var (
 			CloudTrail, CloudWatch, SNS, S3 and VPC (Default).
 		</p>
 		<p>
-			The provided recommendations are provided as a result of controls included in
-			the CIS Level 2.
+			Recommendations are provided in order to comply with all the controls required 
+			by the CIS Level 2.
 		</p>
 		<p>
 			Check the Details and Resources sections to know the compliance status
@@ -130,9 +130,9 @@ var (
 	}
 
 	CISComplianceInfo = report.Vulnerability{
-		Summary: "Information about CIS AWS Foundations Benchmark (BETA)",
+		Summary: "Information About CIS AWS Foundations Benchmark (BETA)",
 		Description: `<p>
-			     Information gathered by executing the CIS benchmark about the account.
+			     Information gathered by executing the CIS benchmark on the account.
 		</p>
 			`,
 		References: []string{
@@ -147,7 +147,7 @@ var (
 type options struct {
 	Region          string   `json:"region"`
 	Groups          []string `json:"groups"`
-	SessionDuration int      `json:"sessionDuration"` // In secs.
+	SessionDuration int      `json:"session_duration"` // In secs.
 	SecurityLevel   *byte    `json:"security_level"`
 }
 
@@ -248,13 +248,13 @@ func main() {
 }
 
 func groupsFromOpts(opts options) ([]string, error) {
-	// If ROLFP level is specified then it defines the group to use.
+	// If the security level is specified then it defines the group to use.
 	if opts.SecurityLevel == nil {
 		return opts.Groups, nil
 	}
 	level := *opts.SecurityLevel
 	if level < 0 || level > 2 {
-		return nil, errors.New("invalid rolfp level value")
+		return nil, errors.New("invalid security level value")
 	}
 
 	if level == 0 || level == 1 {

--- a/cmd/vulcan-prowler/prowler.go
+++ b/cmd/vulcan-prowler/prowler.go
@@ -37,17 +37,17 @@ type entry struct {
 		prowler -r eu-west-1 -g cislevel1 -T 3600 -M json
 */
 
-func buildParams(opts options) []string {
+func buildParams(region string, groups []string) []string {
 	return []string{
-		"-r", opts.Region,
-		"-g", strings.Join(opts.Groups, ","),
+		"-r", region,
+		"-g", strings.Join(groups, ","),
 		"-M", reportFormat,
 	}
 }
 
-func runProwler(ctx context.Context, opts options) (*prowlerReport, error) {
-	logger.Infof("using options: %#v", opts)
-	params := buildParams(opts)
+func runProwler(ctx context.Context, region string, groups []string) (*prowlerReport, error) {
+	logger.Infof("using region: %+v, and groups: %+v", region, groups)
+	params := buildParams(region, groups)
 
 	version, _, err := command.Execute(ctx, logger, prowlerCmd, "-V")
 	if err != nil {


### PR DESCRIPTION
This PR modifies the vulcan-prowler check to accept a security level for an account and set the CIS Level to check for depending on that level.
Concretely:

- If the security level is 0 or 1, it will execute the controls included in the CIS Level 1.
- If the security is not specified or it is 2, it will execute the controls included in the CIS Level 2.

Apart from that there are some small improvements on the resources table and in the descriptions of the vulnerabilities. 
