### PR TITLE
Update ZAP check to work with most recent features

### DIFF
--- a/cmd/vulcan-zap/Dockerfile
+++ b/cmd/vulcan-zap/Dockerfile
@@ -1,4 +1,4 @@
-FROM owasp/zap2docker-stable
+FROM owasp/zap2docker-weekly
 
 USER root
 RUN chown -R zap /zap/

--- a/cmd/vulcan-zap/Dockerfile
+++ b/cmd/vulcan-zap/Dockerfile
@@ -1,4 +1,4 @@
-FROM owasp/zap2docker-weekly
+FROM owasp/zap2docker-weekly:w2020-08-03
 
 USER root
 RUN chown -R zap /zap/

--- a/cmd/vulcan-zap/main.go
+++ b/cmd/vulcan-zap/main.go
@@ -72,14 +72,14 @@ func main() {
 		}
 		client, err := zap.NewClient(cfg)
 		if err != nil {
-			return fmt.Errorf("error configuring the ZAP proxy client: %v", err)
+			return fmt.Errorf("error configuring the ZAP proxy client: %w", err)
 		}
 
 		client.Core().SetOptionDefaultUserAgent("Vulcan - Security Scanner - vulcan@adevinta.com")
 
 		targetURL, err := url.Parse(target)
 		if err != nil {
-			return fmt.Errorf("error parsing target URL: %v", err)
+			return fmt.Errorf("error parsing target URL: %w", err)
 		}
 
 		if opt.Username != "" {
@@ -97,7 +97,7 @@ func main() {
 		client.Spider().SetOptionMaxDepth(opt.Depth)
 		resp, err := client.Spider().Scan(targetURL.String(), "", "", "", "")
 		if err != nil {
-			return fmt.Errorf("error executing the spider: %v", err)
+			return fmt.Errorf("error executing the spider: %w", err)
 		}
 
 		v, ok := resp["scan"]
@@ -120,7 +120,7 @@ func main() {
 			time.Sleep(10 * time.Second)
 			resp, err := client.Spider().Status(scanid)
 			if err != nil {
-				return fmt.Errorf("error getting the status of the spider: %v", err)
+				return fmt.Errorf("error getting the status of the spider: %w", err)
 			}
 
 			v, ok := resp["status"]
@@ -159,14 +159,14 @@ func main() {
 		client.AjaxSpider().SetOptionMaxCrawlDepth(opt.Depth)
 		resp, err = client.AjaxSpider().Scan(targetURL.String(), "", "", "")
 		if err != nil {
-			return fmt.Errorf("error executing the AJAX spider: %v", err)
+			return fmt.Errorf("error executing the AJAX spider: %w", err)
 		}
 
 		for {
 			time.Sleep(10 * time.Second)
 			resp, err := client.AjaxSpider().Status()
 			if err != nil {
-				return fmt.Errorf("error getting the status of the AJAX spider: %v", err)
+				return fmt.Errorf("error getting the status of the AJAX spider: %w", err)
 			}
 
 			v, ok := resp["status"]
@@ -193,7 +193,7 @@ func main() {
 
 			resp, err = client.Ascan().Scan(targetURL.String(), "True", "False", "", "", "", "")
 			if err != nil {
-				return fmt.Errorf("error executing the active scan: %v", err)
+				return fmt.Errorf("error executing the active scan: %w", err)
 			}
 
 			v, ok := resp["scan"]
@@ -213,7 +213,7 @@ func main() {
 
 				resp, err := ascan.Status(scanid)
 				if err != nil {
-					return fmt.Errorf("error getting the status of the scan: %v", err)
+					return fmt.Errorf("error getting the status of the scan: %w", err)
 				}
 
 				v, ok := resp["status"]

--- a/cmd/vulcan-zap/main.go
+++ b/cmd/vulcan-zap/main.go
@@ -53,8 +53,8 @@ func main() {
 		}()
 
 		// Wait for ZAP to be available.
+		logger.Debug("Waiting for ZAP proxy...")
 		for {
-			logger.Debug("Waiting for ZAP proxy...")
 			time.Sleep(time.Second)
 			conn, _ := net.DialTimeout("tcp", "127.0.0.1:8080", time.Second)
 			if conn != nil {
@@ -117,7 +117,7 @@ func main() {
 		}
 
 		for {
-			time.Sleep(1 * time.Second)
+			time.Sleep(10 * time.Second)
 			resp, err := client.Spider().Status(scanid)
 			if err != nil {
 				return fmt.Errorf("error getting the status of the scan: %v", err)
@@ -173,7 +173,7 @@ func main() {
 			}
 
 			for {
-				time.Sleep(5 * time.Second)
+				time.Sleep(5 * time.Minute)
 
 				ascan := client.Ascan()
 

--- a/cmd/vulcan-zap/main.go
+++ b/cmd/vulcan-zap/main.go
@@ -184,7 +184,7 @@ func main() {
 			}
 		}
 
-		logger.Debug("Waiting for spider results...")
+		logger.Debug("Waiting for AJAX spider results...")
 		time.Sleep(5 * time.Second)
 
 		// Scan actively only if explicitly indicated.

--- a/cmd/vulcan-zap/main.go
+++ b/cmd/vulcan-zap/main.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/url"
 	"os/exec"
 	"strconv"
 	"time"
@@ -76,7 +77,10 @@ func main() {
 
 		client.Core().SetOptionDefaultUserAgent("Vulcan - Security Scanner - vulcan@adevinta.com")
 
-		targetURL := hostnameToURL(target, opt.Port)
+		targetURL, err := url.Parse(target)
+		if err != nil {
+			return fmt.Errorf("error parsing target URL: %v", err)
+		}
 
 		if opt.Username != "" {
 			auth := client.Authentication()

--- a/cmd/vulcan-zap/manifest.toml
+++ b/cmd/vulcan-zap/manifest.toml
@@ -1,3 +1,3 @@
 Description = "Runs an OWASP ZAP passive or active scan"
 Timeout = 7200 # 2 hour. Expressed in seconds as an integer.
-Options = '{"depth": 3, "active": true}'
+Options = '{"depth": 2, "active": true}'

--- a/cmd/vulcan-zap/manifest.toml
+++ b/cmd/vulcan-zap/manifest.toml
@@ -1,3 +1,3 @@
 Description = "Runs an OWASP ZAP passive or active scan"
 Timeout = 7200 # 2 hour. Expressed in seconds as an integer.
-Options = '{"depth": 2, "active": true}'
+Options = '{"depth": 3, "active": true}'

--- a/cmd/vulcan-zap/manifest.toml
+++ b/cmd/vulcan-zap/manifest.toml
@@ -1,3 +1,4 @@
 Description = "Runs an OWASP ZAP passive or active scan"
-Timeout = 7200 # 2 hour. Expressed in seconds as an integer.
+AssetTypes = ["WebAddress"]
+Timeout = 7200 # 2 hours. Expressed in seconds as an integer.
 Options = '{"depth": 2, "active": true}'

--- a/cmd/vulcan-zap/zap.go
+++ b/cmd/vulcan-zap/zap.go
@@ -72,6 +72,7 @@ func processAlert(a map[string]interface{}) (report.Vulnerability, error) {
 	if err != nil {
 		return report.Vulnerability{}, fmt.Errorf("Error converting CWE ID for \"%v\".", v.Summary)
 	}
+	// ZAP uses 2^32-1 as CWE ID for vulnerabilities without a known CWE.
 	if cweIDInt < math.MaxInt32-1 {
 		v.CWEID = uint32(cweIDInt)
 	}

--- a/cmd/vulcan-zap/zap.go
+++ b/cmd/vulcan-zap/zap.go
@@ -1,54 +1,13 @@
 package main
 
 import (
-	"crypto/tls"
 	"errors"
 	"fmt"
-	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
-	"time"
 
 	report "github.com/adevinta/vulcan-report"
 )
-
-func hostnameToURL(hostname string, port int) url.URL {
-	u := url.URL{}
-	u.Path = "//"
-
-	if port != 0 {
-		u.Host = fmt.Sprintf("%v:%v", hostname, port)
-	} else {
-		u.Host = hostname
-	}
-
-	for _, scheme := range []string{"https", "http"} {
-		u.Scheme = scheme
-
-		timeout := 10 * time.Second
-		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
-
-		client := &http.Client{
-			CheckRedirect: func(req *http.Request, via []*http.Request) error {
-				return http.ErrUseLastResponse
-			},
-			Transport: tr,
-			Timeout:   timeout,
-		}
-
-		_, err := client.Get(u.String())
-		if err != nil {
-			continue
-		}
-
-		return u
-	}
-
-	return url.URL{}
-}
 
 func riskToScore(risk string) float32 {
 	switch risk {

--- a/cmd/vulcan-zap/zap.go
+++ b/cmd/vulcan-zap/zap.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -71,7 +72,9 @@ func processAlert(a map[string]interface{}) (report.Vulnerability, error) {
 	if err != nil {
 		return report.Vulnerability{}, fmt.Errorf("Error converting CWE ID for \"%v\".", v.Summary)
 	}
-	v.CWEID = uint32(cweIDInt)
+	if cweIDInt < math.MaxInt32 {
+		v.CWEID = uint32(cweIDInt)
+	}
 
 	resMethod, ok := a["method"].(string)
 	if !ok {

--- a/cmd/vulcan-zap/zap.go
+++ b/cmd/vulcan-zap/zap.go
@@ -72,7 +72,7 @@ func processAlert(a map[string]interface{}) (report.Vulnerability, error) {
 	if err != nil {
 		return report.Vulnerability{}, fmt.Errorf("Error converting CWE ID for \"%v\".", v.Summary)
 	}
-	if cweIDInt < math.MaxInt32 {
+	if cweIDInt < math.MaxInt32-1 {
 		v.CWEID = uint32(cweIDInt)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/lair-framework/go-nmap v0.0.0-20181105160706-3b9bafddefee
 	github.com/miekg/dns v1.1.27 // indirect
 	github.com/sirupsen/logrus v1.4.2
-	github.com/zaproxy/zap-api-go v0.0.0-20180130105416-8779ab35e992
+	github.com/zaproxy/zap-api-go v0.0.0-20200806070313-98cebd2f39ae
 	golang.org/x/crypto v0.0.0-20200210222208-86ce3cb69678 // indirect
 	golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4 // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,6 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
-github.com/zaproxy/zap-api-go v0.0.0-20180130105416-8779ab35e992 h1:1bcuck5Gp81nV9YQ2/V8KzmQLOEpng0JlnHSqUsV7/Q=
-github.com/zaproxy/zap-api-go v0.0.0-20180130105416-8779ab35e992/go.mod h1:lBqVZ0hGhjkg0sL/0O7IG1QE+kv3sRQMtpKuyZi5llY=
 github.com/zaproxy/zap-api-go v0.0.0-20200806070313-98cebd2f39ae h1:HB5NPea57rppW36a/QhoMCQ50YQZjMZG+ghUr36uNso=
 github.com/zaproxy/zap-api-go v0.0.0-20200806070313-98cebd2f39ae/go.mod h1:lBqVZ0hGhjkg0sL/0O7IG1QE+kv3sRQMtpKuyZi5llY=
 golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,8 @@ github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/zaproxy/zap-api-go v0.0.0-20180130105416-8779ab35e992 h1:1bcuck5Gp81nV9YQ2/V8KzmQLOEpng0JlnHSqUsV7/Q=
 github.com/zaproxy/zap-api-go v0.0.0-20180130105416-8779ab35e992/go.mod h1:lBqVZ0hGhjkg0sL/0O7IG1QE+kv3sRQMtpKuyZi5llY=
+github.com/zaproxy/zap-api-go v0.0.0-20200806070313-98cebd2f39ae h1:HB5NPea57rppW36a/QhoMCQ50YQZjMZG+ghUr36uNso=
+github.com/zaproxy/zap-api-go v0.0.0-20200806070313-98cebd2f39ae/go.mod h1:lBqVZ0hGhjkg0sL/0O7IG1QE+kv3sRQMtpKuyZi5llY=
 golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=


### PR DESCRIPTION
This PR implements the following improvements to the ZAP check:

- Updates to the latest available weekly version of ZAP.
- Makes use of the new AJAX spider to better crawl single page applications.
- Supports WebAddress type assets exclusively to remove guessing the server.
- Reduce progress polling frequency to avoid spamming the persistence server.
- Fix bug where unknown CWE ID were reported as 2^32-1 overflowing the DB.