### PR TITLE
vulcan-prowler fix nil pointer

### DIFF
--- a/cmd/vulcan-prowler/main.go
+++ b/cmd/vulcan-prowler/main.go
@@ -67,6 +67,7 @@ var (
 			"https://github.com/toniblyx/prowler",
 			"https://www.cisecurity.org/benchmark/amazon_web_services/",
 		},
+		Score: report.SeverityThresholdMedium,
 	}
 
 	CISLevel1Compliance = report.Vulnerability{

--- a/cmd/vulcan-prowler/main.go
+++ b/cmd/vulcan-prowler/main.go
@@ -217,12 +217,9 @@ func main() {
 		if opts.SecurityLevel == nil {
 			v = CISCompliance
 
-		}
-		if *opts.SecurityLevel == 0 || *opts.SecurityLevel == 1 {
+		} else if *opts.SecurityLevel == 0 || *opts.SecurityLevel == 1 {
 			v = CISLevel1Compliance
-		}
-
-		if *opts.SecurityLevel == 2 {
+		} else {
 			v = CISLevel2Compliance
 		}
 		fv, err := fillCisLevelVuln(&v, r, alias, opts.SecurityLevel)

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/FiloSottile/CVE-2016-2107 v0.0.0-20160513191821-17e9b6082f41 h1:MFhC+GK98qlnNBJWKHx2hcErBWV518xAklawIrICY4g=
 github.com/FiloSottile/CVE-2016-2107 v0.0.0-20160513191821-17e9b6082f41/go.mod h1:Y00ZD1FNSMTFSqW2BeVIivVCIV4XcF7u3tJzq4YwZ5I=
+github.com/PuerkitoBio/goquery v1.5.1 h1:PSPBGne8NIUWw+/7vFBV+kG2J/5MOjbzc7154OaKCSE=
+github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
 github.com/adevinta/gozuul v0.0.0-20191210100135-8808882dea1f h1:I74NfMCY6nR2+/u1VfrGeKtXI2ghQf+i2AHJ6oOiSb4=
 github.com/adevinta/gozuul v0.0.0-20191210100135-8808882dea1f/go.mod h1:QljCYZvsmWhtbnOxlvqGC19JEQwx5gh5+rQDgtKPul4=
 github.com/adevinta/restuss v0.0.0-20200401171945-cc64e2b9dd21 h1:UTCSVBGTK78jV0F/pDsYLIKRzmJD7pkz/vqP0OVOHfM=
@@ -18,6 +20,8 @@ github.com/adevinta/vulcan-types v0.0.0-20191212162849-8e75a5e4503c h1:eHQ2/O9I0
 github.com/adevinta/vulcan-types v0.0.0-20191212162849-8e75a5e4503c/go.mod h1:gflQ+QgTgSGHMJp+kUnogHadjASIDcvCTwH1v/fqT3U=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
+github.com/andybalholm/cascadia v1.1.0 h1:BuuO6sSfQNFRu1LppgbD25Hr2vLYW25JvxHs5zzsLTo=
+github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apuigsech/seekret v0.0.0-20161231092511-9b1f7ea1b3fd/go.mod h1:MQe9ewnl3lqr6Ien+Pr9iZRlDIhzXdu4HjtPI6PCGlI=
@@ -135,6 +139,7 @@ golang.org/x/crypto v0.0.0-20191202143827-86a70503ff7e/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200210222208-86ce3cb69678 h1:wCWoJcFExDgyYx2m2hpHgwz8W3+FPdfldvIgzqDIhyg=
 golang.org/x/crypto v0.0.0-20200210222208-86ce3cb69678/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
+golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181220203305-927f97764cc3 h1:eH6Eip3UpmR+yM/qI9Ijluzb1bNv/cAU/n+6l8tRSis=
 golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=


### PR DESCRIPTION
This PR fixes two issues in the vulcan-check-prowler :
- A nil pointer dereference that was happening when no security level was specified.
- The score of a the vulnerability added when no security level was specified is now properly set to Medium.