### PR TITLE
Add vulcan-github-alerts check to report vulnerable dependencies in Github 

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ Currently there's no vendoring provided for this project.
 38. **vulcan-trivy** - Checks if a Docker image uses vulnerable packages or dependencies using Trivy
 39. **vulcan-exposed-http-resources** - Checks if a web address exposes sensitive resources
 40. **vulcan-prowler** - Checks compliance against CIS AWS Foundations Benchmark
+41. **vulcan-github-alerts** - Retrieves existing vulnerability alerts for a Github repository

--- a/cmd/vulcan-github-alerts/Dockerfile
+++ b/cmd/vulcan-github-alerts/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine
+ADD vulcan-github-alerts /vulcan-github-alerts
+CMD ["/vulcan-github-alerts"]

--- a/cmd/vulcan-github-alerts/local.toml.example
+++ b/cmd/vulcan-github-alerts/local.toml.example
@@ -1,2 +1,5 @@
 [Check]
-Target = "https://github.com/adevinta/vulcan-checks" # The Github user used by Vulcan needs to be administrator of the repository.
+# The Github user used by Vulcan needs to be administrator of the repository or its organization.
+# Additionally, the Github token that Vulcan uses requires "repo:public_repo" permissions.
+# In order to work with private repositories, the token requires full "repo" permissions.
+Target = "https://github.com/adevinta/vulcan-checks"

--- a/cmd/vulcan-github-alerts/local.toml.example
+++ b/cmd/vulcan-github-alerts/local.toml.example
@@ -1,0 +1,2 @@
+[Check]
+Target = "https://github.com/adevinta/vulcan-checks" # The Github user used by Vulcan needs to be administrator of the repository.

--- a/cmd/vulcan-github-alerts/main.go
+++ b/cmd/vulcan-github-alerts/main.go
@@ -82,6 +82,7 @@ type ExtendedAdvisory struct {
 	References  []struct {
 		URL string `json:"url"`
 	} `json:"references"`
+	WithdrawnAt            string `json:"withdrawnAt"`
 	VulnerableVersionRange string
 	// NOTE: Github currently always returns the FirstPatchedVersion field empty.
 	FirstPatchedVersion string
@@ -151,6 +152,12 @@ func main() {
 		dependencies := map[string]*dependencyData{}
 		for _, alert := range alerts {
 			vuln := alert.SecurityVulnerability
+
+			// If the advisory has been withdrawn, we will ignore it.
+			if vuln.Advisory.WithdrawnAt != "" {
+				continue
+			}
+
 			vuln.Advisory.VulnerableVersionRange = vuln.VulnerableVersionRange
 			vuln.Advisory.FirstPatchedVersion = vuln.FirstPatchedVersion
 			advisoryScore := scoreSeverity(vuln.Advisory.Severity)

--- a/cmd/vulcan-github-alerts/main.go
+++ b/cmd/vulcan-github-alerts/main.go
@@ -218,7 +218,7 @@ func main() {
 			}
 
 			rows = append(rows, map[string]string{
-				"Name":                     dependencyName,
+				"Dependency":               dependencyName,
 				"Ecosystem":                dependencyData.ecosystem,
 				"Vulnerabilities":          fmt.Sprintf("%v", dependencyData.vulnCount),
 				"Max. Severity":            dependencyData.maxSeverity,
@@ -241,14 +241,14 @@ func main() {
 				vj, _ := strconv.Atoi(rows[j]["Vulnerabilities"])
 				return vi > vj
 			default:
-				return rows[i]["Name"] < rows[j]["Name"]
+				return rows[i]["Dependency"] < rows[j]["Dependency"]
 			}
 		})
 
 		dependenciesResources := report.ResourcesGroup{
 			Name: "Vulnerable Dependencies",
 			Header: []string{
-				"Name",
+				"Dependency",
 				"Ecosystem",
 				"Vulnerabilities",
 				"Max. Severity",

--- a/cmd/vulcan-github-alerts/main.go
+++ b/cmd/vulcan-github-alerts/main.go
@@ -107,7 +107,6 @@ func main() {
 
 		cleanGraphqlQuery := strings.Join(strings.Fields(graphqlQuery), " ")
 		var jsonData = []byte(fmt.Sprintf(`{"query": "%s"}`, fmt.Sprintf(cleanGraphqlQuery, org, repo)))
-		fmt.Println(string(jsonData))
 		req, err := http.NewRequest("POST", githubURL.String(), bytes.NewBuffer(jsonData))
 		req.Header.Set("Authorization", "Bearer "+os.Getenv("GITHUB_ENTERPRISE_TOKEN"))
 
@@ -127,8 +126,6 @@ func main() {
 		if err != nil {
 			return err
 		}
-
-		fmt.Println(alertsResponse)
 
 		packages := map[string][]ExtendedAdvisory{}
 		alerts := alertsResponse.Data.Repository.VulnerabilityAlerts.Details

--- a/cmd/vulcan-github-alerts/main.go
+++ b/cmd/vulcan-github-alerts/main.go
@@ -13,10 +13,11 @@ import (
 	"strconv"
 	"strings"
 
-	semver "github.com/Masterminds/semver/v3"
 	check "github.com/adevinta/vulcan-check-sdk"
 	"github.com/adevinta/vulcan-check-sdk/state"
 	report "github.com/adevinta/vulcan-report"
+
+	semver "github.com/Masterminds/semver/v3"
 )
 
 const graphqlAPIPath = "/api/graphql"
@@ -122,6 +123,8 @@ func main() {
 			return err
 		}
 
+		// We clean the URL to extract the organization and repository names.
+		targetURL.Path = strings.TrimSuffix(targetURL.Path, ".git")
 		splitPath := strings.Split(targetURL.Path, "/")
 		org, repo := splitPath[1], splitPath[2]
 

--- a/cmd/vulcan-github-alerts/main.go
+++ b/cmd/vulcan-github-alerts/main.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+
+	check "github.com/adevinta/vulcan-check-sdk"
+	"github.com/adevinta/vulcan-check-sdk/state"
+	report "github.com/adevinta/vulcan-report"
+)
+
+const graphqlAPIPath = "/api/graphql"
+const graphqlQuery = `
+query { 
+	repository(owner:\"%v\", name:\"%v\") {
+		vulnerabilityAlerts(last: 100) {
+			number: totalCount
+			pagination: pageInfo { endCursor hasNextPage }
+			details: nodes {
+				securityVulnerability {
+					advisory { summary description severity references { url } }
+					package { name ecosystem }
+					vulnerableVersionRange
+					firstPatchedVersion { identifier }
+				}
+			}
+		}
+	}
+}
+`
+
+type alertsData struct {
+	Data struct {
+		Repository struct {
+			VulnerabilityAlerts struct {
+				Number     int `json:"number"`
+				Pagination struct {
+					EndCursor   string `json:"endCursor"`
+					HasNextPage bool   `json:"hasNextPage"`
+				} `json:"pagination"`
+				Details []struct {
+					SecurityVulnerability struct {
+						Advisory ExtendedAdvisory `json:"advisory"`
+						Package  struct {
+							Name      string `json:"name"`
+							Ecosystem string `json:"ecosystem"`
+						} `json:"package"`
+						VulnerableVersionRange string `json:"vulnerableVersionRange"`
+						FirstPatchedVersion    string `json:"firstPatchedVersion"`
+					} `json:"securityVulnerability"`
+				} `json:"details"`
+			} `json:"vulnerabilityAlerts"`
+		} `json:"repository"`
+	} `json:"data"`
+}
+
+// ExtendedAdvisory adds the VulnerableVersionRange to the returned structure.
+type ExtendedAdvisory struct {
+	Summary     string `json:"summary"`
+	Description string `json:"description"`
+	Severity    string `json:"severity"`
+	References  []struct {
+		URL string `json:"url"`
+	} `json:"references"`
+	VulnerableVersionRange string
+	FirstPatchedVersion    string
+}
+
+var (
+	checkName = "vulcan-github-alerts"
+	baseVuln  = report.Vulnerability{
+		Description:     "",
+		CWEID:           937,
+		Score:           report.SeverityThresholdNone,
+		Recommendations: []string{"Update the dependency to a version higher than any of the vulnerable version ranges."},
+	}
+)
+
+func main() {
+	run := func(ctx context.Context, target string, optJSON string, state state.State) (err error) {
+		if target == "" {
+			return errors.New("check target missing")
+		}
+
+		targetURL, err := url.Parse(target)
+		if err != nil {
+			return err
+		}
+
+		splitPath := strings.Split(targetURL.Path, "/")
+		org, repo := splitPath[1], splitPath[2]
+
+		// TODO: Support multiple authenticated Github Enterprise instances.
+		githubURL, err := url.Parse(os.Getenv("GITHUB_ENTERPRISE_ENDPOINT"))
+		if err != nil {
+			return err
+		}
+		githubURL.Path = graphqlAPIPath
+
+		cleanGraphqlQuery := strings.Join(strings.Fields(graphqlQuery), " ")
+		var jsonData = []byte(fmt.Sprintf(`{"query": "%s"}`, fmt.Sprintf(cleanGraphqlQuery, org, repo)))
+		fmt.Println(string(jsonData))
+		req, err := http.NewRequest("POST", githubURL.String(), bytes.NewBuffer(jsonData))
+		req.Header.Set("Authorization", "Bearer "+os.Getenv("GITHUB_ENTERPRISE_TOKEN"))
+
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode >= 300 {
+			return fmt.Errorf("received status %v", resp.Status)
+		}
+
+		var alertsResponse alertsData
+		err = json.NewDecoder(resp.Body).Decode(&alertsResponse)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(alertsResponse)
+
+		packages := map[string][]ExtendedAdvisory{}
+		alerts := alertsResponse.Data.Repository.VulnerabilityAlerts.Details
+		for _, alert := range alerts {
+			vuln := alert.SecurityVulnerability
+			vuln.Advisory.VulnerableVersionRange = vuln.VulnerableVersionRange
+			vuln.Advisory.FirstPatchedVersion = vuln.FirstPatchedVersion
+			if packages[vuln.Package.Name] != nil {
+				packages[vuln.Package.Name] = append(packages[vuln.Package.Name], vuln.Advisory)
+			} else {
+				packages[vuln.Package.Name] = []ExtendedAdvisory{vuln.Advisory}
+			}
+		}
+
+		for packageName, packageAdvisories := range packages {
+			vuln := baseVuln
+			if len(packageAdvisories) > 1 {
+				vuln.Summary = fmt.Sprintf(`Multiple vulnerabilities in "%v" dependency`, packageName)
+			} else {
+				vuln.Summary = fmt.Sprintf(`Vulnerability in "%v" dependency`, packageName)
+			}
+
+			var rows []map[string]string
+			for i, advisory := range packageAdvisories {
+				vuln.Description += advisory.Description
+				if i != 0 {
+					vuln.Description += "\n\n"
+				}
+
+				for _, reference := range advisory.References {
+					vuln.References = append(vuln.References, reference.URL)
+				}
+
+				advisoryScore := scoreSeverity(advisory.Severity)
+				if advisoryScore > vuln.Score {
+					vuln.Score = advisoryScore
+				}
+
+				if advisory.FirstPatchedVersion == "" {
+					advisory.FirstPatchedVersion = "Unknown"
+				}
+				rows = append(rows, map[string]string{
+					"Severity":                 advisory.Severity,
+					"Vulnerable Version Range": advisory.VulnerableVersionRange,
+					"First Patched Version":    advisory.FirstPatchedVersion,
+				})
+			}
+
+			sort.Slice(rows, func(i, j int) bool {
+				si := scoreSeverity(rows[i]["Severity"])
+				sj := scoreSeverity(rows[j]["Severity"])
+				return si > sj
+			})
+
+			versions := report.ResourcesGroup{
+				Name: "Affected Versions",
+				Header: []string{
+					"Severity",
+					"Vulnerable Version Range",
+					"First Patched Version",
+				},
+				Rows: rows,
+			}
+
+			vuln.Resources = []report.ResourcesGroup{versions}
+
+			state.AddVulnerabilities(vuln)
+		}
+
+		return nil
+	}
+
+	c := check.NewCheckFromHandler(checkName, run)
+
+	c.RunAndServe()
+}
+
+func scoreSeverity(githubSeverity string) float32 {
+	switch githubSeverity {
+	case "CRITICAL":
+		return report.SeverityThresholdCritical
+	case "HIGH":
+		return report.SeverityThresholdHigh
+	case "MODERATE":
+		return report.SeverityThresholdMedium
+	case "LOW":
+		return report.SeverityThresholdLow
+	default:
+		return report.SeverityThresholdNone
+	}
+}

--- a/cmd/vulcan-github-alerts/manifest.toml
+++ b/cmd/vulcan-github-alerts/manifest.toml
@@ -1,0 +1,5 @@
+Description = "Retrieves existing vulnerability alerts for a Github repository"
+Timeout = 600
+AssetTypes = ["GitRepository"]
+RequiredVars = ["GITHUB_ENTERPRISE_ENDPOINT", "GITHUB_ENTERPRISE_TOKEN"]
+Options = ""

--- a/cmd/vulcan-github-alerts/manifest.toml
+++ b/cmd/vulcan-github-alerts/manifest.toml
@@ -1,5 +1,8 @@
 Description = "Retrieves existing vulnerability alerts for a Github repository"
 Timeout = 60
 AssetTypes = ["GitRepository"]
+# The Github user used by Vulcan needs to be administrator of the repository or its organization.
+# Additionally, the Github token that Vulcan uses requires "repo:public_repo" permissions.
+# In order to work with private repositories, the token requires full "repo" permissions.
 RequiredVars = ["GITHUB_ENTERPRISE_ENDPOINT", "GITHUB_ENTERPRISE_TOKEN"]
 Options = ""

--- a/cmd/vulcan-github-alerts/manifest.toml
+++ b/cmd/vulcan-github-alerts/manifest.toml
@@ -1,5 +1,5 @@
 Description = "Retrieves existing vulnerability alerts for a Github repository"
-Timeout = 600
+Timeout = 60
 AssetTypes = ["GitRepository"]
 RequiredVars = ["GITHUB_ENTERPRISE_ENDPOINT", "GITHUB_ENTERPRISE_TOKEN"]
 Options = ""

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/FiloSottile/CVE-2016-2107 v0.0.0-20160513191821-17e9b6082f41
+	github.com/Masterminds/semver/v3 v3.1.0
 	github.com/adevinta/gozuul v0.0.0-20191210100135-8808882dea1f
 	github.com/adevinta/restuss v0.0.0-20200401171945-cc64e2b9dd21
 	github.com/adevinta/vulcan-check-sdk v0.0.0-20200401140623-e76035f8c5a7

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,9 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/FiloSottile/CVE-2016-2107 v0.0.0-20160513191821-17e9b6082f41 h1:MFhC+GK98qlnNBJWKHx2hcErBWV518xAklawIrICY4g=
 github.com/FiloSottile/CVE-2016-2107 v0.0.0-20160513191821-17e9b6082f41/go.mod h1:Y00ZD1FNSMTFSqW2BeVIivVCIV4XcF7u3tJzq4YwZ5I=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver/v3 v3.1.0 h1:Y2lUDsFKVRSYGojLJ1yLxSXdMmMYTYls0rCvoqmMUQk=
+github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/adevinta/gozuul v0.0.0-20191210100135-8808882dea1f h1:I74NfMCY6nR2+/u1VfrGeKtXI2ghQf+i2AHJ6oOiSb4=
 github.com/adevinta/gozuul v0.0.0-20191210100135-8808882dea1f/go.mod h1:QljCYZvsmWhtbnOxlvqGC19JEQwx5gh5+rQDgtKPul4=
 github.com/adevinta/restuss v0.0.0-20200401171945-cc64e2b9dd21 h1:UTCSVBGTK78jV0F/pDsYLIKRzmJD7pkz/vqP0OVOHfM=

--- a/vulcan-github-alerts.json
+++ b/vulcan-github-alerts.json
@@ -1,0 +1,1 @@
+{"check_id":"1e1642e0-dda7-40f8-90cf-53b543e08e25","checktype_name":"","checktype_version":"","status":"FAILED","target":"https://github.mpi-internal.com/heimdall/heimdall-admin","options":"","tag":"","start_time":"2020-10-02T14:14:27.559080077Z","end_time":"2020-10-02T14:14:27.559401668Z","vulnerabilities":null,"error":"Post \"/api/graphql\": unsupported protocol scheme \"\""}

--- a/vulcan-github-alerts.json
+++ b/vulcan-github-alerts.json
@@ -1,1 +1,0 @@
-{"check_id":"1e1642e0-dda7-40f8-90cf-53b543e08e25","checktype_name":"","checktype_version":"","status":"FAILED","target":"https://github.mpi-internal.com/heimdall/heimdall-admin","options":"","tag":"","start_time":"2020-10-02T14:14:27.559080077Z","end_time":"2020-10-02T14:14:27.559401668Z","vulnerabilities":null,"error":"Post \"/api/graphql\": unsupported protocol scheme \"\""}


### PR DESCRIPTION
This check uses the [Github GraphQL API](https://docs.github.com/en/free-pro-team@latest/graphql/reference/objects#securityvulnerability) to retrieve [security alerts related to vulnerable dependencies](https://docs.github.com/en/free-pro-team@latest/github/managing-security-vulnerabilities/about-alerts-for-vulnerable-dependencies) present for a repository. The check also tries to determine the minimum version necessary for each dependency to fix all the vulnerabilities reported, since the API does not currently populate the corresponding field.

Example:
![image](https://user-images.githubusercontent.com/7050335/95575250-a486c080-0a2e-11eb-8545-08260bbc4504.png)
