### PR TITLE
Add product, version and CPEs to Vulners details

### DIFF
--- a/cmd/vulcan-vulners/main.go
+++ b/cmd/vulcan-vulners/main.go
@@ -276,8 +276,11 @@ func analyzeReport(target string, nmapReport *gonmap.NmapRun) ([]report.Vulnerab
 						v.Vuln.Score = f.Score
 					}
 				}
-				v.Vuln.Details = fmt.Sprintf("%sFound in %s at port %d/%s\n", v.Vuln.Details, host.Hostnames[0].Name, port.PortId, port.Protocol)
-
+				v.Vuln.Details = fmt.Sprintf(
+					"%sHost: %s\nPort: %d/%s\nProduct: %s\nVersion: %s\nCPEs: %v\n\n",
+					v.Vuln.Details, host.Hostnames[0].Name, port.PortId, port.Protocol,
+					port.Service.Product, port.Service.Version, port.Service.CPEs,
+				)
 				uniqueVulns[summary] = v
 			}
 			if done {
@@ -316,7 +319,11 @@ func analyzeReport(target string, nmapReport *gonmap.NmapRun) ([]report.Vulnerab
 					v.Vuln.Score = f.Score
 				}
 			}
-			v.Vuln.Details = fmt.Sprintf("%sFound in %s at port %d/%s\n", v.Vuln.Details, host.Hostnames[0].Name, port.PortId, port.Protocol)
+			v.Vuln.Details = fmt.Sprintf(
+				"%sHost: %s\nPort: %d/%s\nProduct: %s\nVersion: %s\nCPEs: %v\n\n",
+				v.Vuln.Details, host.Hostnames[0].Name, port.PortId, port.Protocol,
+				port.Service.Product, port.Service.Version, port.Service.CPEs,
+			)
 			uniqueVulns[summary] = v
 		}
 	}


### PR DESCRIPTION
The goal of this PR is to allow users to identify what software versions were present at the time of the scan in order to, for example, quickly identify if a finding was a false positive or if the software has been updated after the scan.