### PR TITLE
Improve false positive detection mechanisms

### DIFF
--- a/cmd/vulcan-exposed-http-resources/main.go
+++ b/cmd/vulcan-exposed-http-resources/main.go
@@ -90,7 +90,7 @@ var (
 
 	// falseOKSuffixes are the suffixes that will be added to the randomly
 	// generated resource to check if the server is returning false OK responses.
-	falseOKSuffixes = [...]string{"", "/", ".txt", ".html", ".php", ".asp", ".jsp"}
+	falseOKSuffixes = [...]string{"", "/", "/images/", ".txt", ".html", ".php", ".asp", ".jsp"}
 
 	// falsePositivesMessage is the message that will be displayed
 	// in the details section if the exposed resources of the check


### PR DESCRIPTION
This PR improves the false positive detection mechanisms in the `vulcan-http-exposed-resources` check.

The mechanisms implemeted are:
1. Querying randomly generated resource paths to identify if the server returns false `200 OK` statuses.
2. Performing the exact same check twice to identify if the server returns `200 OK` responses inconsistently.
3. Validating if the rate at which the server responds `200 OK` to requests for exposed resources is abnormally high.

Additionally, a new informational vulnerability will be added to the report in the first case in order to keep a record of the server behaviour in the case of false negatives. All false positives are now logged in the details section and, if false positives are identified, the vulnerability is reported with the highest score among the high confidence findings.