### PR TITLE
Detect an unauthenticated SSRF in Hystrix Dashboard

### DIFF
--- a/cmd/vulcan-exposed-http-resources/main.go
+++ b/cmd/vulcan-exposed-http-resources/main.go
@@ -296,9 +296,19 @@ func checkResource(targetURL *url.URL, httpResource Resource) []map[string]strin
 					return
 				}
 
-				targetResource.Path = path.Join(targetResource.Path, p)
+				pURL, err := url.Parse(p)
+				if err != nil {
+					logger.Error(err)
+					return
+				}
+
+				targetResource.Path = path.Join(targetResource.Path, pURL.Path)
+				// Allow to specify query strings in the paths.
 				if strings.HasSuffix(p, "/") && !strings.HasSuffix(targetResource.Path, "/") {
 					targetResource.Path += "/"
+				}
+				if pURL.RawQuery != "" {
+					targetResource.RawQuery = pURL.RawQuery
 				}
 
 				positive, err := checkPath(targetResource, httpResource)

--- a/cmd/vulcan-exposed-http-resources/resources.yaml
+++ b/cmd/vulcan-exposed-http-resources/resources.yaml
@@ -417,3 +417,10 @@
   status: 200
   severity: 5.0
   description: Potentially exposed WordPress administration login page.
+
+- paths:
+  - "proxy.stream?origin=http://example.com"
+  status: 200
+  regex: "This domain is for use in illustrative examples in documents"
+  severity: 9.0
+  description: Unauthenticated SSRF in Hystrix dashboard 


### PR DESCRIPTION
This PR introduces the following modifications to the vulcan-exposed-http-resources check:

- Allows to specify query strings in the paths sections of the resources.yaml file, so for instance now we can specify a resource like this:
```
- paths:
  - "/somewhere?query=this"
  status: 200
  severity: 1.0
  description: a vuln found
```
- Add a new resource that detects that the following vulnerability:  https://tanzu.vmware.com/security/cve-2020-5412

In order to reduce the odds of returning a false positive the check will try to exploit the vuln by checking if it is able to reach the "http://example.com" url from the target server.

To test the check, do the following:

1. Clone the repository: https://github.com/manelmontilla/docker-hystrix-demo
2. Inside the root dir of the repository execute: ``` docker-compose up ```
3. in the directory cmd/vulcan-exposed-http-resources/ of the checks repository add a local.toml file with the following contents:
``` 
[Log]
LogLevel = "info"
[Check]
Target = "http://host.docker.internal:38080"
```   
4. Run the check by executing the following command from the root of the checks repo dir:
```
vulcan-build-images -r cmd/vulcan-exposed-http-resources
```
