### PR TITLE
Increase polling interval for nessus check

### DIFF
--- a/cmd/vulcan-nessus/main.go
+++ b/cmd/vulcan-nessus/main.go
@@ -12,6 +12,7 @@ var (
 )
 
 type options struct {
+	DelayRange      int  `json:"delay_range"`
 	PollingInterval int  `json:"polling_interval"`
 	BasicAuth       bool `json:"basic_auth"`
 	Delete          bool `json:"delete"`

--- a/cmd/vulcan-nessus/nessus.go
+++ b/cmd/vulcan-nessus/nessus.go
@@ -76,7 +76,9 @@ func (r *runner) Run(ctx context.Context, target, assetType, optJSON string, sta
 	if delayRange <= 0 {
 		delayRange = defDelayRange
 	}
-	time.Sleep(time.Duration(rand.Intn(delayRange)) * time.Second)
+	delay := time.Duration(rand.Intn(delayRange)) * time.Second
+	logger.Infof("Delaying startup for %v", delay)
+	time.Sleep(delay)
 
 	logger = logger.WithFields(log.Fields{
 		"target":    target,

--- a/cmd/vulcan-nessus/nessus.go
+++ b/cmd/vulcan-nessus/nessus.go
@@ -20,6 +20,13 @@ import (
 	report "github.com/adevinta/vulcan-report"
 )
 
+const (
+	// Default polling interval is 5min.
+	defPollingInterval = 5 * 60
+	// Default delay range is 1min.
+	defDelayRange = 60
+)
+
 // Runner executes a Nessus check.
 type Runner interface {
 	Run(ctx context.Context) (err error)
@@ -53,12 +60,23 @@ func (r *runner) Run(ctx context.Context, target, assetType, optJSON string, sta
 	}
 	policyID := int64(p)
 
-	pollingInterval := opt.PollingInterval
 	basicAuth := opt.BasicAuth
 	r.Delete = opt.Delete
+
+	pollingInterval := opt.PollingInterval
 	if pollingInterval <= 0 {
-		pollingInterval = 30
+		pollingInterval = defPollingInterval
 	}
+
+	// In order to not overload Tenable API
+	// sleep a random time from within a range
+	// so we distribute initial spike during
+	// scans creation process.
+	delayRange := opt.DelayRange
+	if delayRange <= 0 {
+		delayRange = defDelayRange
+	}
+	time.Sleep(time.Duration(rand.Intn(delayRange)) * time.Second)
 
 	logger = logger.WithFields(log.Fields{
 		"target":    target,


### PR DESCRIPTION
This PR modifies nessus check in order to:

- Increase the default polling interval from 30s to 5min
- Set an initial delay time before starting communication with Tenable API.

This is in order to try to mitigate spikes and overloading of Tenable API during scans.