### PR TITLE
Improve AWS trusted advisor checks refreshing

### DIFF
--- a/cmd/vulcan-aws-trusted-advisor/local.toml.example
+++ b/cmd/vulcan-aws-trusted-advisor/local.toml.example
@@ -1,4 +1,4 @@
 [Check]
 Target = "arn:aws:iam::123456789012:root"
 AssetType = "AWSAccount"
-Options = '{"vulcan_assume_role_url":"http://localhost:8080/assume","role":"SecurityAuditRole", "refresh_timeout": 5}'
+Options = '{"vulcan_assume_role_url":"http://localhost:8080/assume","role":"SecurityAuditRole", "refresh_timeout": 60}'

--- a/cmd/vulcan-aws-trusted-advisor/main.go
+++ b/cmd/vulcan-aws-trusted-advisor/main.go
@@ -157,6 +157,7 @@ func scanAccount(opt options, target, assetType string, logger *logrus.Entry, st
 	// poll it's status and wait up until opt.RefreshTimeout
 	if enqueued > 0 {
 		t := time.NewTicker(time.Duration(opt.RefreshTimeout) * time.Second)
+		defer t.Stop()
 
 	LOOP:
 		for {
@@ -190,7 +191,6 @@ func scanAccount(opt options, target, assetType string, logger *logrus.Entry, st
 				time.Sleep(rfrshInterval)
 			}
 		}
-		t.Stop()
 	}
 
 	// Retrieve checks summaries

--- a/cmd/vulcan-aws-trusted-advisor/main.go
+++ b/cmd/vulcan-aws-trusted-advisor/main.go
@@ -40,6 +40,8 @@ var (
 
 	additionalResourcesPattern = regexp.MustCompile(`href=\"(?P<resource>.*?)\"`)
 	templateResource           = "$resource"
+
+	rfrshInterval = time.Duration(5 * time.Second)
 )
 
 type options struct {
@@ -112,6 +114,7 @@ func scanAccount(opt options, target, assetType string, logger *logrus.Entry, st
 
 	s := support.New(sess, &aws.Config{Credentials: creds})
 
+	// Retrieve checks list
 	checks, err := s.DescribeTrustedAdvisorChecks(
 		&support.DescribeTrustedAdvisorChecksInput{
 			Language: aws.String("en"),
@@ -120,6 +123,7 @@ func scanAccount(opt options, target, assetType string, logger *logrus.Entry, st
 		return err
 	}
 
+	// Refresh checks
 	checkIds := []*string{}
 	enqueued := 0
 	for _, check := range checks.Checks {
@@ -148,12 +152,45 @@ func scanAccount(opt options, target, assetType string, logger *logrus.Entry, st
 			enqueued++
 		}
 	}
-	// Let's chill a bit before getting results
-	if enqueued > 0 {
-		logger.Infof("waiting for checks to be refreshed. Sleeping for %d seconds ...", opt.RefreshTimeout)
-		time.Sleep(time.Duration(opt.RefreshTimeout) * time.Second)
-	}
 
+	// Start polling for checks refresh status
+	t := time.NewTicker(time.Duration(opt.RefreshTimeout) * time.Second)
+
+LOOP:
+	for {
+		select {
+		case <-t.C:
+			break LOOP
+		default:
+			checkStatus, err := s.DescribeTrustedAdvisorCheckRefreshStatuses(
+				&support.DescribeTrustedAdvisorCheckRefreshStatusesInput{
+					CheckIds: checkIds,
+				},
+			)
+			if err != nil {
+				if awsErr, ok := err.(awserr.Error); ok {
+					if awsErr.Code() != "InvalidParameterValueException" {
+						return err
+					}
+				}
+			}
+			var pending bool
+			for _, cs := range checkStatus.Statuses {
+				if *cs.Status == "enqueued" || *cs.Status == "processing" {
+					pending = true
+					break
+				}
+			}
+			if !pending {
+				break LOOP
+			}
+			logger.Infof("Waiting for checks to be refreshed. Sleeping for %v...", rfrshInterval)
+			time.Sleep(rfrshInterval)
+		}
+	}
+	t.Stop()
+
+	// Retrieve checks summaries
 	var alias *string
 	for _, v := range checks.Checks {
 		// Ignore results if we can't know the category

--- a/cmd/vulcan-aws-trusted-advisor/manifest.toml
+++ b/cmd/vulcan-aws-trusted-advisor/manifest.toml
@@ -1,4 +1,4 @@
 Description = "Runs an AWS Trusted Advisor check against an AWS account"
 AssetTypes = ["AWSAccount"]
 RequiredVars = ["VULCAN_ASSUME_ROLE_ENDPOINT", "ROLE_NAME"]
-Options = '{"refresh_timeout": 5}'
+Options = '{"refresh_timeout": 60}'


### PR DESCRIPTION
This PR improves the logic put in place for the vulcan-aws-trusted-advisor when some of its checks are enqueued for processing so we should wait up until the defined refresh TO option polling their status to verify if they are refreshed.
Also for this purpose it modifies the default refresh timeout from 5 to 60 seconds.