### PR TITLE
cmd/vulcan-nessus: delete nessus scans by default

### DIFF
--- a/cmd/vulcan-nessus/main.go
+++ b/cmd/vulcan-nessus/main.go
@@ -12,10 +12,10 @@ var (
 )
 
 type options struct {
-	DelayRange      int  `json:"delay_range"`
-	PollingInterval int  `json:"polling_interval"`
-	BasicAuth       bool `json:"basic_auth"`
-	Delete          bool `json:"delete"`
+	DelayRange      int   `json:"delay_range"`
+	PollingInterval int   `json:"polling_interval"`
+	BasicAuth       bool  `json:"basic_auth"`
+	Delete          *bool `json:"delete"`
 }
 
 func main() {

--- a/cmd/vulcan-nessus/nessus.go
+++ b/cmd/vulcan-nessus/nessus.go
@@ -61,7 +61,12 @@ func (r *runner) Run(ctx context.Context, target, assetType, optJSON string, sta
 	policyID := int64(p)
 
 	basicAuth := opt.BasicAuth
-	r.Delete = opt.Delete
+
+	// Default value for delete option is TRUE
+	r.Delete = true
+	if opt.Delete != nil {
+		r.Delete = *opt.Delete
+	}
 
 	pollingInterval := opt.PollingInterval
 	if pollingInterval <= 0 {


### PR DESCRIPTION
Hi, this PR modifies the default value for the `delete scan` option from `vulcan-nessus` check. Previously, the default value was `false`. If the requester didn't specify a value for `delete`, then the check would not delete any generated scans in Nessus. Now the default value is `true`, so the check will only preserve a Nessus Scan if the requester explicitly defines the `delete` option as `false`.