### PR TITLE
Fix counterproductive panics in retirejs

### DIFF
--- a/cmd/vulcan-retirejs/main_test.go
+++ b/cmd/vulcan-retirejs/main_test.go
@@ -17,9 +17,9 @@ import (
 
 	"golang.org/x/net/html"
 
-	"github.com/adevinta/vulcan-check-sdk"
+	check "github.com/adevinta/vulcan-check-sdk"
 	"github.com/adevinta/vulcan-check-sdk/state"
-	"github.com/adevinta/vulcan-report"
+	report "github.com/adevinta/vulcan-report"
 )
 
 func init() {
@@ -154,7 +154,10 @@ func TestFindScriptFiles(t *testing.T) {
 	localAddr = ts.URL
 
 	expected := 2
-	got := findScriptFiles(localAddr)
+	got, err := findScriptFiles(localAddr)
+	if err != nil {
+		t.Fatalf("expected no error but got: %v", err)
+	}
 	if got != expected {
 		t.Fatalf("wrong value for findInlineScripts. Got: %v , expected: %v", got, expected)
 	}
@@ -168,7 +171,10 @@ func TestInlineScripts(t *testing.T) {
 	defer ts.Close()
 	localAddr = ts.URL
 	expected := 1
-	got := findInlineScripts(localAddr)
+	got, err := findInlineScripts(localAddr)
+	if err != nil {
+		t.Fatalf("expected no error but got: %v", err)
+	}
 	if got != expected {
 		t.Fatalf("wrong value for findInlineScripts. Got: %v , expected: %v", got, expected)
 	}
@@ -181,7 +187,11 @@ func TestFindTargetHTML(t *testing.T) {
 	}))
 
 	defer ts.Close()
-	if getTargetHTML(ts.URL).FirstChild.Data != "html" {
+	htmlNode, err := getTargetHTML(ts.URL)
+	if err != nil {
+		t.Fatalf("exepected no error but got: %v", err)
+	}
+	if htmlNode.FirstChild.Data != "html" {
 		t.Fatalf("Cannot find target html")
 	}
 }


### PR DESCRIPTION
This PR modifies vulcan-retirejs check to avoid panicking on purpose for unnecessary reasons during check handle execution.
Panicking in this situations for permanent errors makes vulcan-agent handle the check execution in an incorrect way, which instead of marking it as FAILED, returns the message to the queue and makes this eventually be processed `MaxRead` times by the agent with the same execution process and result for each time.

Instead, the correct behavior implemented here is to return an error from within check handle execution so the vulcan-agent can parse it correctly and set the check status to FAILED on its first execution.