### PR TITLE
Disable nmap reporting progress

### DIFF
--- a/cmd/vulcan-exposed-db/main.go
+++ b/cmd/vulcan-exposed-db/main.go
@@ -24,6 +24,8 @@ import (
 type options struct {
 	// Nmap timing parameter.
 	Timing int `json:"timing"`
+	// Return status updates on the progress of the check
+	ReportProgress bool `json:"reportProgress"`
 	// List of potential database ports to scan for.
 	Ports []string `json:"ports"`
 	// Regex to verify that the exposed service is a database.
@@ -151,7 +153,7 @@ func main() {
 			"-p":  strings.Join(opt.Ports, ","),
 		}
 
-		nmapRunner := nmap.NewNmapCheck(target, state, opt.Timing, nmapParams)
+		nmapRunner := nmap.NewNmapCheck(target, state, opt.Timing, opt.ReportProgress, nmapParams)
 		nmapReport, _, err := nmapRunner.Run(ctx)
 		if err != nil {
 			return err

--- a/cmd/vulcan-exposed-db/main.go
+++ b/cmd/vulcan-exposed-db/main.go
@@ -25,7 +25,7 @@ type options struct {
 	// Nmap timing parameter.
 	Timing int `json:"timing"`
 	// Return status updates on the progress of the check
-	ReportProgress bool `json:"reportProgress"`
+	ReportProgress bool `json:"report_progress"`
 	// List of potential database ports to scan for.
 	Ports []string `json:"ports"`
 	// Regex to verify that the exposed service is a database.

--- a/cmd/vulcan-exposed-ftp/main.go
+++ b/cmd/vulcan-exposed-ftp/main.go
@@ -24,7 +24,7 @@ type options struct {
 	// Nmap timing parameter.
 	Timing int `json:"timing"`
 	// Return status updates on the progress of the check
-	ReportProgress bool `json:"reportProgress"`
+	ReportProgress bool `json:"report_progress"`
 	// List of ports that will be scanned
 	Ports []string `json:"ports"`
 	// Scanning allowed open FTP Ports

--- a/cmd/vulcan-exposed-ftp/main.go
+++ b/cmd/vulcan-exposed-ftp/main.go
@@ -23,6 +23,8 @@ import (
 type options struct {
 	// Nmap timing parameter.
 	Timing int `json:"timing"`
+	// Return status updates on the progress of the check
+	ReportProgress bool `json:"reportProgress"`
 	// List of ports that will be scanned
 	Ports []string `json:"ports"`
 	// Scanning allowed open FTP Ports
@@ -180,7 +182,7 @@ func main() {
 			"--script-args": scriptArgs,
 		}
 
-		nmapRunner := nmap.NewNmapCheck(target, state, opt.Timing, nmapParams)
+		nmapRunner := nmap.NewNmapCheck(target, state, opt.Timing, opt.ReportProgress, nmapParams)
 		nmapReport, _, err := nmapRunner.Run(ctx)
 		if err != nil {
 			return err

--- a/cmd/vulcan-exposed-hdfs/main.go
+++ b/cmd/vulcan-exposed-hdfs/main.go
@@ -31,6 +31,8 @@ const defaultTiming = 4
 type options struct {
 	// Nmap timing parameter.
 	Timing int `json:"timing"`
+	// Return status updates on the progress of the check
+	ReportProgress bool `json:"reportProgress"`
 	// List of potential ports to scan for.
 	Ports []string `json:"ports"`
 	// Regex to verify that the exposed service is a hadoop port.
@@ -231,7 +233,7 @@ func run(ctx context.Context, target, assetType, optJSON string, state checkstat
 		"-p":  strings.Join(opt.Ports, ","),
 	}
 
-	nmapRunner := nmap.NewNmapCheck(target, state, opt.Timing, nmapParams)
+	nmapRunner := nmap.NewNmapCheck(target, state, opt.Timing, opt.ReportProgress, nmapParams)
 	nmapReport, _, err := nmapRunner.Run(ctx)
 	if err != nil {
 		return err

--- a/cmd/vulcan-exposed-hdfs/main.go
+++ b/cmd/vulcan-exposed-hdfs/main.go
@@ -32,7 +32,7 @@ type options struct {
 	// Nmap timing parameter.
 	Timing int `json:"timing"`
 	// Return status updates on the progress of the check
-	ReportProgress bool `json:"reportProgress"`
+	ReportProgress bool `json:"report_progress"`
 	// List of potential ports to scan for.
 	Ports []string `json:"ports"`
 	// Regex to verify that the exposed service is a hadoop port.

--- a/cmd/vulcan-exposed-http/main.go
+++ b/cmd/vulcan-exposed-http/main.go
@@ -23,7 +23,7 @@ type options struct {
 	// Nmap timing parameter.
 	Timing int `json:"timing"`
 	// Return status updates on the progress of the check
-	ReportProgress bool `json:"reportProgress"`
+	ReportProgress bool `json:"report_progress"`
 	// List of potential database ports to scan for.
 	Ports []string `json:"ports"`
 }

--- a/cmd/vulcan-exposed-http/main.go
+++ b/cmd/vulcan-exposed-http/main.go
@@ -22,6 +22,8 @@ import (
 type options struct {
 	// Nmap timing parameter.
 	Timing int `json:"timing"`
+	// Return status updates on the progress of the check
+	ReportProgress bool `json:"reportProgress"`
 	// List of potential database ports to scan for.
 	Ports []string `json:"ports"`
 }
@@ -161,7 +163,7 @@ func main() {
 			"-p":  strings.Join(opt.Ports, ","),
 		}
 
-		nmapRunner := nmap.NewNmapCheck(target, state, opt.Timing, nmapParams)
+		nmapRunner := nmap.NewNmapCheck(target, state, opt.Timing, opt.ReportProgress, nmapParams)
 		nmapReport, _, err := nmapRunner.Run(ctx)
 		if err != nil {
 			return err

--- a/cmd/vulcan-exposed-router-ports/main.go
+++ b/cmd/vulcan-exposed-router-ports/main.go
@@ -22,6 +22,8 @@ import (
 type options struct {
 	// Nmap timing parameter.
 	Timing int `json:"timing"`
+	// Return status updates on the progress of the check
+	ReportProgress bool `json:"reportProgress"`
 	// List of potential database ports to scan for.
 	Ports []string `json:"ports"`
 }
@@ -133,7 +135,7 @@ func main() {
 			"-p":  strings.Join(opt.Ports, ","),
 		}
 
-		nmapRunner := nmap.NewNmapCheck(target, state, opt.Timing, nmapParams)
+		nmapRunner := nmap.NewNmapCheck(target, state, opt.Timing, opt.ReportProgress, nmapParams)
 		nmapReport, _, err := nmapRunner.Run(ctx)
 		if err != nil {
 			return err

--- a/cmd/vulcan-exposed-router-ports/main.go
+++ b/cmd/vulcan-exposed-router-ports/main.go
@@ -23,7 +23,7 @@ type options struct {
 	// Nmap timing parameter.
 	Timing int `json:"timing"`
 	// Return status updates on the progress of the check
-	ReportProgress bool `json:"reportProgress"`
+	ReportProgress bool `json:"report_progress"`
 	// List of potential database ports to scan for.
 	Ports []string `json:"ports"`
 }

--- a/cmd/vulcan-exposed-services/main.go
+++ b/cmd/vulcan-exposed-services/main.go
@@ -23,6 +23,8 @@ import (
 type options struct {
 	// Nmap timing parameter.
 	Timing int `json:"timing"`
+	// Return status updates on the progress of the check
+	ReportProgress bool `json:"reportProgress"`
 
 	/* Lists of whitelisted TCP and UDP ports.
 	 *
@@ -194,7 +196,7 @@ func main() {
 			nmapUDPParams["--exclude-ports"] = uint16ArrayToString(opt.WhitelistedUDPPorts, ",")
 		}
 
-		nmapUDPRunner := nmap.NewNmapCheck(target, state, opt.Timing, nmapUDPParams)
+		nmapUDPRunner := nmap.NewNmapCheck(target, state, opt.Timing, opt.ReportProgress, nmapUDPParams)
 		nmapUDPReport, _, err := nmapUDPRunner.Run(ctx)
 		if err != nil {
 			return err

--- a/cmd/vulcan-exposed-services/main.go
+++ b/cmd/vulcan-exposed-services/main.go
@@ -24,7 +24,7 @@ type options struct {
 	// Nmap timing parameter.
 	Timing int `json:"timing"`
 	// Return status updates on the progress of the check
-	ReportProgress bool `json:"reportProgress"`
+	ReportProgress bool `json:"report_progress"`
 
 	/* Lists of whitelisted TCP and UDP ports.
 	 *

--- a/cmd/vulcan-exposed-services/main.go
+++ b/cmd/vulcan-exposed-services/main.go
@@ -173,7 +173,7 @@ func main() {
 			nmapTCPParams["--exclude-ports"] = uint16ArrayToString(opt.WhitelistedTCPPorts, ",")
 		}
 
-		nmapTCPRunner := nmap.NewNmapCheck(target, state, opt.Timing, nmapTCPParams)
+		nmapTCPRunner := nmap.NewNmapCheck(target, state, opt.Timing, opt.ReportProgress, nmapTCPParams)
 		nmapTCPReport, _, err := nmapTCPRunner.Run(ctx)
 		if err != nil {
 			return err

--- a/cmd/vulcan-host-discovery/main.go
+++ b/cmd/vulcan-host-discovery/main.go
@@ -22,6 +22,8 @@ import (
 type options struct {
 	// Nmap timing parameter.
 	Timing int `json:"timing"`
+	// Return status updates on the progress of the check
+	ReportProgress bool `json:"reportProgress"`
 
 	/***
 	 * If a list of known hosts is provided, the check will return results only when
@@ -188,7 +190,7 @@ func main() {
 		}
 
 		// Ideally, the target should be a subnet mask, but /32 address will also work.
-		nmapRunner := nmap.NewNmapCheck(target, state, opt.Timing, nmapParams)
+		nmapRunner := nmap.NewNmapCheck(target, state, opt.Timing, opt.ReportProgress, nmapParams)
 		nmapReport, _, err := nmapRunner.Run(ctx)
 		if err != nil {
 			return err

--- a/cmd/vulcan-host-discovery/main.go
+++ b/cmd/vulcan-host-discovery/main.go
@@ -23,7 +23,7 @@ type options struct {
 	// Nmap timing parameter.
 	Timing int `json:"timing"`
 	// Return status updates on the progress of the check
-	ReportProgress bool `json:"reportProgress"`
+	ReportProgress bool `json:"report_progress"`
 
 	/***
 	 * If a list of known hosts is provided, the check will return results only when

--- a/cmd/vulcan-smtp-open-relay/main.go
+++ b/cmd/vulcan-smtp-open-relay/main.go
@@ -28,6 +28,8 @@ import (
 type options struct {
 	// Nmap timing parameter.
 	Timing int `json:"timing"`
+	// Return status updates on the progress of the check
+	ReportProgress bool `json:"reportProgress"`
 	// List of potential database ports to scan for.
 	Ports []string `json:"ports"`
 }
@@ -135,7 +137,7 @@ func main() {
 			"--script": "smtp-open-relay.nse",
 		}
 
-		nmapRunner := nmap.NewNmapCheck(target, state, opt.Timing, nmapParams)
+		nmapRunner := nmap.NewNmapCheck(target, state, opt.Timing, opt.ReportProgress, nmapParams)
 		nmapReport, _, err := nmapRunner.Run(ctx)
 		if err != nil {
 			return err

--- a/cmd/vulcan-smtp-open-relay/main.go
+++ b/cmd/vulcan-smtp-open-relay/main.go
@@ -29,7 +29,7 @@ type options struct {
 	// Nmap timing parameter.
 	Timing int `json:"timing"`
 	// Return status updates on the progress of the check
-	ReportProgress bool `json:"reportProgress"`
+	ReportProgress bool `json:"report_progress"`
 	// List of potential database ports to scan for.
 	Ports []string `json:"ports"`
 }

--- a/cmd/vulcan-vulners/main.go
+++ b/cmd/vulcan-vulners/main.go
@@ -40,7 +40,7 @@ type options struct {
 	// Nmap timing parameter.
 	Timing int `json:"timing"`
 	// Return status updates on the progress of the check
-	ReportProgress bool `json:"reportProgress"`
+	ReportProgress bool `json:"report_progress"`
 }
 
 var (

--- a/cmd/vulcan-vulners/main.go
+++ b/cmd/vulcan-vulners/main.go
@@ -39,6 +39,8 @@ const (
 type options struct {
 	// Nmap timing parameter.
 	Timing int `json:"timing"`
+	// Return status updates on the progress of the check
+	ReportProgress bool `json:"reportProgress"`
 }
 
 var (
@@ -372,7 +374,7 @@ func run(ctx context.Context, target, assetType, optJSON string, state checkstat
 		"-sV": "",
 	}
 
-	nmapRunner := nmap.NewNmapCheck(target, state, opt.Timing, nmapParams)
+	nmapRunner := nmap.NewNmapCheck(target, state, opt.Timing, opt.ReportProgress, nmapParams)
 	nmapReport, _, err := nmapRunner.Run(ctx)
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Microsoft/go-winio v0.4.16 // indirect
 	github.com/adevinta/gozuul v0.0.0-20191210100135-8808882dea1f
 	github.com/adevinta/restuss v0.0.0-20200401171945-cc64e2b9dd21
-	github.com/adevinta/vulcan-check-sdk v0.0.0-20210322152808-3df77aef4b3c
+	github.com/adevinta/vulcan-check-sdk v0.0.0-20210413123949-c3970505a010
 	github.com/adevinta/vulcan-report v0.0.0-20190503133936-d8a2d4cb18ff
 	github.com/adevinta/vulcan-types v0.0.0-20200922093209-437fd6d5ab11
 	github.com/apuigsech/seekret v0.0.0-20191114110023-80f5fc8b8678

--- a/go.sum
+++ b/go.sum
@@ -16,12 +16,8 @@ github.com/adevinta/gozuul v0.0.0-20191210100135-8808882dea1f h1:I74NfMCY6nR2+/u
 github.com/adevinta/gozuul v0.0.0-20191210100135-8808882dea1f/go.mod h1:QljCYZvsmWhtbnOxlvqGC19JEQwx5gh5+rQDgtKPul4=
 github.com/adevinta/restuss v0.0.0-20200401171945-cc64e2b9dd21 h1:UTCSVBGTK78jV0F/pDsYLIKRzmJD7pkz/vqP0OVOHfM=
 github.com/adevinta/restuss v0.0.0-20200401171945-cc64e2b9dd21/go.mod h1:8dMhe4LgwRr18Izq4gJHEb0JGWyDd4k7eJawvSwaqNM=
-github.com/adevinta/vulcan-check-sdk v0.0.0-20210127084628-4364dce799fa h1:dyXlTLQKcv09+UopubZWZOrSxoAFKy0R8kJi7k/NW54=
-github.com/adevinta/vulcan-check-sdk v0.0.0-20210127084628-4364dce799fa/go.mod h1:uaUXwBqTeGMI7p+nmnhkloAv/Hwm+2xBMr/HfXSvWoI=
-github.com/adevinta/vulcan-check-sdk v0.0.0-20210322101147-4c25da65bd36 h1:NEGYApVN+HGcvTl0623MV2rVips3LFS5B+Um3ZycfEI=
-github.com/adevinta/vulcan-check-sdk v0.0.0-20210322101147-4c25da65bd36/go.mod h1:uaUXwBqTeGMI7p+nmnhkloAv/Hwm+2xBMr/HfXSvWoI=
-github.com/adevinta/vulcan-check-sdk v0.0.0-20210322152808-3df77aef4b3c h1:ZjNEG8XrPfDVpwgWF0UdOnnSbcMFeQY3D/GoLjYH96U=
-github.com/adevinta/vulcan-check-sdk v0.0.0-20210322152808-3df77aef4b3c/go.mod h1:uaUXwBqTeGMI7p+nmnhkloAv/Hwm+2xBMr/HfXSvWoI=
+github.com/adevinta/vulcan-check-sdk v0.0.0-20210413123949-c3970505a010 h1:pSC5aeG7VvrXSwQSCaUicnC0cMiwhcQqqjPHv4PFyFU=
+github.com/adevinta/vulcan-check-sdk v0.0.0-20210413123949-c3970505a010/go.mod h1:uaUXwBqTeGMI7p+nmnhkloAv/Hwm+2xBMr/HfXSvWoI=
 github.com/adevinta/vulcan-report v0.0.0-20190503133936-d8a2d4cb18ff h1:ZazuZSOfV8oo70SWdjLQi+In4GSmJCA2rwsliyz9KNs=
 github.com/adevinta/vulcan-report v0.0.0-20190503133936-d8a2d4cb18ff/go.mod h1:GtAon6TymHFTOPwRdR7SHun/TSM1kyPMQYXxGLTR8eQ=
 github.com/adevinta/vulcan-types v0.0.0-20200922093209-437fd6d5ab11 h1:BTW+HVwpnrSJ18KOJaQyh9AsRip1bWXRCmWuUcoECZo=


### PR DESCRIPTION
Summary of changes:
- related to https://github.com/adevinta/vulcan-check-sdk/pull/19, change all checks using the **nmap** helper provided by the SDK to disable the progress reporting

(This PR won't build until https://github.com/adevinta/vulcan-check-sdk/pull/19 is merged first)
