### PR TITLE
Revert "Remove beta status from Trivy check (#96)"

### DIFF
--- a/cmd/vulcan-trivy/vulcan-trivy.go
+++ b/cmd/vulcan-trivy/vulcan-trivy.go
@@ -66,7 +66,7 @@ type vulnerability struct {
 }
 
 var vuln = report.Vulnerability{
-	Summary:     "Outdated Packages in Docker Image",
+	Summary:     "Outdated Packages in Docker Image (BETA)",
 	Description: "Vulnerabilities have been found in outdated packages installed in the Docker image.",
 	CWEID:       937,
 	Recommendations: []string{


### PR DESCRIPTION
This reverts commit 302b6066b1183332a8812d4257683221d8d1e342.

The reason for the revert is that we need to rewrite the summary in the issues table of the Vulnerability DB or otherwise teams will be reported duplicated findings with the issue with the new summary and with the old one. We will find a good time to do the rewrite when no scans are running.