### PR TITLE
Include details of the non-existent bucket in s3 subdomain takeover vulnerability

### DIFF
--- a/cmd/vulcan-s3-takeover/main.go
+++ b/cmd/vulcan-s3-takeover/main.go
@@ -91,6 +91,7 @@ func main() {
 			// Don't fail the check if the target can not be accessed.
 			return nil
 		}
+		defer resp.Body.Close()
 
 		logger.WithFields(logrus.Fields{
 			"status_code": resp.StatusCode,
@@ -109,6 +110,7 @@ func main() {
 					}
 
 					if s3Resp.Code == noSuchBucket {
+						s3Takeover.Details += fmt.Sprintf("URL visited: %s\nContent:\n\n%#v\n", website, s3Resp)
 						state.AddVulnerabilities(s3Takeover)
 					}
 				} else if strings.HasPrefix(contentType, "text/html") {
@@ -118,6 +120,7 @@ func main() {
 					}
 
 					if strings.Contains(string(body), noSuchBucket) {
+						s3Takeover.Details += fmt.Sprintf("URL visited: %s\nContent:\n\n%s\n", website, body)
 						state.AddVulnerabilities(s3Takeover)
 					}
 				}


### PR DESCRIPTION
Currently the vulnerability doesn't reflect how actually the information was found and the name of the missing bucket. This PR adds that information inside the vulnerabilty.Details field so the user can understand and reproduce the issue.

<img width="1403" alt="image" src="https://user-images.githubusercontent.com/3331668/121334552-0bd87580-c91a-11eb-804f-938eaf257b3b.png">
