### PR TITLE
vulcan-zap: disable reverse-tabnabbing

### DIFF
--- a/cmd/vulcan-zap/manifest.toml
+++ b/cmd/vulcan-zap/manifest.toml
@@ -4,5 +4,6 @@ Timeout = 36000 # 10 hours. Expressed in seconds as an integer.
 # Disabled scanners:
 # 10062 - PII Disclosure - Too many false positive results.
 # 10003 - Vulnerable JS Library - Duplicates the Retire.js check.
+# 10108 - Reverse Tabnabbing - Not relevant for modern browser versions.
 # Source: https://www.zaproxy.org/docs/alerts/
-Options = '{"depth": 2, "active": true, "min_score": 0, "disabled_scanners": ["10062", "10003"]}'
+Options = '{"depth": 2, "active": true, "min_score": 0, "disabled_scanners": ["10062", "10003", "10108"]}'


### PR DESCRIPTION
This PR modifies the vulcan-zap in order
 
to disable checking for the reverse [tabnabbing alert](https://www.zaproxy.org/docs/alerts/10108/)

 Example, taken from https://owasp.org/www-community/attacks/Reverse_Tabnabbing, of an html that triggers that zap alert:

```HTML
<!-- copied from https://owasp.org/www-community/attacks/Reverse_Tabnabbing -->
<html>
 <body>
  <li><a href="http://bad.example.com" target="_blank">Vulnerable target using html link to open the new page</a></li>
  <button onclick="window.open('https://bad.example.com')">Vulnerable target using javascript to open the new page</button>
 </body>
</html>
```


Report of the vulnerabilities generated by the check when it's run against a page containing the previous html and before applying the modifications:
<img width="977" alt="before" src="https://user-images.githubusercontent.com/87574/123994369-9c601e00-d9cd-11eb-9c4b-116caee6ba3c.png">

Report of the vulnerabilities generated by the check when run against a page containing the previous html and after applying the modifications:
![after](https://user-images.githubusercontent.com/87574/123994468-b0a41b00-d9cd-11eb-82c0-dbc19ef79c57.png)
