### PR TITLE
Removed the 7 to 8 version config for SA-CORE-2019-003

### DIFF
--- a/cmd/vulcan-drupal/vulnerabilities.go
+++ b/cmd/vulcan-drupal/vulnerabilities.go
@@ -507,7 +507,7 @@ var (
 			},
 		},
 		drupalVulnerability{
-			Constraints: []string{">=7,<8", ">=8,<8.5.11", ">=8.6,<8.6.10"},
+			Constraints: []string{">=8,<8.5.11", ">=8.6,<8.6.10"},
 			Vulnerability: report.Vulnerability{
 				Summary:         "Drupal - SA-CORE-2019-003 - Remote Code Execution",
 				CWEID:           937,


### PR DESCRIPTION
Version 7 of drupal isn't vulnerable to this bug, only some specific plugins, so this generates a false positive for us.

I think that if we want to do detection checking for this bug on version 7, we need to either detect the version of those plugins or maybe try to automate a direct detection of the specific bug.