### PR TITLE
Pin masscan alpine version to 3.13.6: avoid usage of faccessat2 syscall

### DIFF
--- a/cmd/vulcan-masscan/Dockerfile
+++ b/cmd/vulcan-masscan/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2019 Adevinta
 
-FROM alpine
-RUN apk update && apk add \
+FROM alpine:3.13.6
+RUN apk update && apk upgrade && apk add \
 	git \
 	gcc \
 	make \


### PR DESCRIPTION
**Summary:**
In recent versions of Alpine, the syscall `faccessat2` has been added to musl which causes problems in the presence of `libseccomp` on the docker host when compiling with `gcc` . This issue makes our builds fail in Travis' workers.

This PR pins Alpine to the latest available version that is not affected by the issue.

**Example of the issue ([link](https://app.travis-ci.com/github/adevinta/vulcan-checks/builds/237173786#L1225-L1233)):**

```
Step 5/8 : RUN make -j
 ---> Running in f6d96ad4c327
make: cc: Operation not permitted
make: git: Operation not permitted
make: cc: Operation not permitted
make: *** [Makefile:109: tmp/crypto-base64.o] Error 127
cc -g -ggdb    -Wall -O2 -c src/crypto-base64.c -o tmp/crypto-base64.o
The command '/bin/sh -c make -j' returned a non-zero code: 2
Error: No such image: vulcansec/vulcan-masscan
Docker image [vulcansec/vulcan-masscan] does not exist
```

**References:**
 - https://gitlab.alpinelinux.org/alpine/aports/-/issues/12321
 - https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0