### PR TITLE
Gitignore improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *.swp
 local.toml
+
+# editor files
+.idea/
+vulcan-checks.iml

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ local.toml
 # editor files
 .idea/
 vulcan-checks.iml
+.vscode/

--- a/cmd/vulcan-aws-alerts/.gitignore
+++ b/cmd/vulcan-aws-alerts/.gitignore
@@ -1,0 +1,1 @@
+vulcan-aws-alerts

--- a/cmd/vulcan-aws-trusted-advisor/.gitignore
+++ b/cmd/vulcan-aws-trusted-advisor/.gitignore
@@ -1,0 +1,1 @@
+vulcan-aws-trusted-advisor

--- a/cmd/vulcan-certinfo/.gitignore
+++ b/cmd/vulcan-certinfo/.gitignore
@@ -1,0 +1,1 @@
+vulcan-certinfo

--- a/cmd/vulcan-dkim/.gitignore
+++ b/cmd/vulcan-dkim/.gitignore
@@ -1,0 +1,1 @@
+vulcan-dkim

--- a/cmd/vulcan-dmarc/.gitignore
+++ b/cmd/vulcan-dmarc/.gitignore
@@ -1,0 +1,1 @@
+vulcan-dmarc

--- a/cmd/vulcan-docker-image/.gitignore
+++ b/cmd/vulcan-docker-image/.gitignore
@@ -1,0 +1,1 @@
+vulcan-docker-image

--- a/cmd/vulcan-drupal/.gitignore
+++ b/cmd/vulcan-drupal/.gitignore
@@ -1,0 +1,1 @@
+vulcan-drupal

--- a/cmd/vulcan-exposed-amt/.gitignore
+++ b/cmd/vulcan-exposed-amt/.gitignore
@@ -1,0 +1,1 @@
+vulcan-exposed-amt

--- a/cmd/vulcan-exposed-bgp/.gitignore
+++ b/cmd/vulcan-exposed-bgp/.gitignore
@@ -1,0 +1,1 @@
+vulcan-exposed-bgp

--- a/cmd/vulcan-exposed-db/.gitignore
+++ b/cmd/vulcan-exposed-db/.gitignore
@@ -1,0 +1,1 @@
+vulcan-exposed-db

--- a/cmd/vulcan-exposed-files/.gitignore
+++ b/cmd/vulcan-exposed-files/.gitignore
@@ -1,0 +1,1 @@
+vulcan-exposed-files

--- a/cmd/vulcan-exposed-ftp/.gitignore
+++ b/cmd/vulcan-exposed-ftp/.gitignore
@@ -1,0 +1,1 @@
+vulcan-exposed-ftp

--- a/cmd/vulcan-exposed-http-endpoint/.gitignore
+++ b/cmd/vulcan-exposed-http-endpoint/.gitignore
@@ -1,0 +1,1 @@
+vulcan-exposed-http-endpoint

--- a/cmd/vulcan-exposed-http-resources/.gitignore
+++ b/cmd/vulcan-exposed-http-resources/.gitignore
@@ -1,0 +1,1 @@
+vulcan-exposed-http-resources

--- a/cmd/vulcan-exposed-http/.gitignore
+++ b/cmd/vulcan-exposed-http/.gitignore
@@ -1,0 +1,1 @@
+vulcan-exposed-http

--- a/cmd/vulcan-exposed-memcached/.gitignore
+++ b/cmd/vulcan-exposed-memcached/.gitignore
@@ -1,0 +1,1 @@
+vulcan-exposed-memcached

--- a/cmd/vulcan-exposed-router-ports/.gitignore
+++ b/cmd/vulcan-exposed-router-ports/.gitignore
@@ -1,0 +1,1 @@
+vulcan-exposed-router-ports

--- a/cmd/vulcan-exposed-ssh/.gitignore
+++ b/cmd/vulcan-exposed-ssh/.gitignore
@@ -1,0 +1,1 @@
+vulcan-exposed-ssh

--- a/cmd/vulcan-exposed-varnish/.gitignore
+++ b/cmd/vulcan-exposed-varnish/.gitignore
@@ -1,0 +1,1 @@
+vulcan-exposed-varnish

--- a/cmd/vulcan-github-alerts/.gitignore
+++ b/cmd/vulcan-github-alerts/.gitignore
@@ -1,0 +1,1 @@
+vulcan-github-alerts

--- a/cmd/vulcan-gozuul/.gitignore
+++ b/cmd/vulcan-gozuul/.gitignore
@@ -1,0 +1,1 @@
+vulcan-gozuul

--- a/cmd/vulcan-heartbleed/.gitignore
+++ b/cmd/vulcan-heartbleed/.gitignore
@@ -1,0 +1,1 @@
+vulcan-heartbleed

--- a/cmd/vulcan-http-headers/.gitignore
+++ b/cmd/vulcan-http-headers/.gitignore
@@ -1,0 +1,1 @@
+vulcan-http-headers

--- a/cmd/vulcan-ipv6/.gitignore
+++ b/cmd/vulcan-ipv6/.gitignore
@@ -1,0 +1,1 @@
+vulcan-ipv6

--- a/cmd/vulcan-lucky/.gitignore
+++ b/cmd/vulcan-lucky/.gitignore
@@ -1,0 +1,1 @@
+vulcan-lucky

--- a/cmd/vulcan-mx/.gitignore
+++ b/cmd/vulcan-mx/.gitignore
@@ -1,0 +1,1 @@
+vulcan-mx

--- a/cmd/vulcan-nessus/.gitignore
+++ b/cmd/vulcan-nessus/.gitignore
@@ -1,0 +1,1 @@
+vulcan-nessus

--- a/cmd/vulcan-prowler/.gitignore
+++ b/cmd/vulcan-prowler/.gitignore
@@ -1,0 +1,1 @@
+vulcan-prowler

--- a/cmd/vulcan-results-load-test/.gitignore
+++ b/cmd/vulcan-results-load-test/.gitignore
@@ -1,0 +1,1 @@
+vulcan-results-load-test

--- a/cmd/vulcan-retirejs/.gitignore
+++ b/cmd/vulcan-retirejs/.gitignore
@@ -1,0 +1,1 @@
+vulcan-retirejs

--- a/cmd/vulcan-s3-takeover/.gitignore
+++ b/cmd/vulcan-s3-takeover/.gitignore
@@ -1,0 +1,1 @@
+vulcan-s3-takeover

--- a/cmd/vulcan-seekret/.gitignore
+++ b/cmd/vulcan-seekret/.gitignore
@@ -1,0 +1,1 @@
+vulcan-seekret

--- a/cmd/vulcan-sleep/.gitignore
+++ b/cmd/vulcan-sleep/.gitignore
@@ -1,0 +1,1 @@
+vulcan-sleep

--- a/cmd/vulcan-smtp-open-relay/.gitignore
+++ b/cmd/vulcan-smtp-open-relay/.gitignore
@@ -1,0 +1,1 @@
+vulcan-smtp-open-relay

--- a/cmd/vulcan-spf/.gitignore
+++ b/cmd/vulcan-spf/.gitignore
@@ -1,0 +1,1 @@
+vulcan-spf

--- a/cmd/vulcan-tls/.gitignore
+++ b/cmd/vulcan-tls/.gitignore
@@ -1,0 +1,1 @@
+vulcan-tls

--- a/cmd/vulcan-trivy/.gitignore
+++ b/cmd/vulcan-trivy/.gitignore
@@ -1,2 +1,1 @@
-local.toml
 vulcan-trivy

--- a/cmd/vulcan-unclassified/.gitignore
+++ b/cmd/vulcan-unclassified/.gitignore
@@ -1,0 +1,1 @@
+vulcan-unclassified

--- a/cmd/vulcan-wpscan/.gitignore
+++ b/cmd/vulcan-wpscan/.gitignore
@@ -1,0 +1,1 @@
+vulcan-wpscan

--- a/cmd/vulcan-zap/.gitignore
+++ b/cmd/vulcan-zap/.gitignore
@@ -1,0 +1,1 @@
+vulcan-zap


### PR DESCRIPTION
Deleted a checked in binary file that I'm guessing shouldn't be there `cmd/vulcan-aws-trusted-advisor/vulcan-aws-trusted-advisor`.

Added gitignore rules for all binaries generated by the checks.