### PR TITLE
Expand vulcan-github-alerts vulnerabilities and add labels

### DIFF
--- a/cmd/vulcan-github-alerts/main.go
+++ b/cmd/vulcan-github-alerts/main.go
@@ -271,12 +271,13 @@ func main() {
 
 		for _, r := range rows {
 			vulnerability := report.Vulnerability{
+				Summary: "Vulnerable Code Dependencies in Github Repository",
+				Description: `Dependencies used by the code in this Github repository have published security vulnerabilities. 
+You can find more specific information in the resources table for the repository.`,
 				Fingerprint:      helpers.ComputeFingerprint(fmt.Sprintf("%v", r)),
 				AffectedResource: fmt.Sprintf("%s:%s", r["Ecosystem"], r["Dependency"]),
 				Score:            scoreSeverity(r["Max. Severity"]),
-				Summary:          "Vulnerable Code Dependencies in Github Repository",
 				Labels:           []string{"potential", "dependency", "code", "github"},
-				Description:      fmt.Sprintf("Dependency [%s] installed by [%s] have published security vulnerabilities.\nYou can find more specific information in the resources table for the repository.", r["Dependency"], r["Ecosystem"]),
 				ImpactDetails:    "The vulnerable dependencies may be introducing vulnerabilities into the software that uses them.",
 				CWEID:            937,
 				Recommendations:  []string{"Update the dependency to at least the minimum recommended version in the resources table."},

--- a/cmd/vulcan-github-alerts/main.go
+++ b/cmd/vulcan-github-alerts/main.go
@@ -105,17 +105,8 @@ type dependencyData struct {
 }
 
 var (
-	checkName              = "vulcan-github-alerts"
-	logger                 = check.NewCheckLog(checkName)
-	vulnerableDependencies = report.Vulnerability{
-		Summary: "Vulnerable Code Dependencies in Github Repository",
-		Description: `Dependencies used by the code in this Github repository have published security vulnerabilities. 
-You can find more specific information in the resources table for the repository.`,
-		ImpactDetails:   "The vulnerable dependencies may be introducing vulnerabilities into the software that uses them.",
-		CWEID:           937,
-		Score:           report.SeverityThresholdNone,
-		Recommendations: []string{"Update all dependencies to at least the minimum recommended version in the resources table."},
-	}
+	checkName = "vulcan-github-alerts"
+	logger    = check.NewCheckLog(checkName)
 )
 
 func main() {

--- a/cmd/vulcan-github-alerts/main.go
+++ b/cmd/vulcan-github-alerts/main.go
@@ -274,7 +274,7 @@ func main() {
 				Summary: "Vulnerable Code Dependencies in Github Repository",
 				Description: `Dependencies used by the code in this Github repository have published security vulnerabilities. 
 You can find more specific information in the resources table for the repository.`,
-				Fingerprint:      helpers.ComputeFingerprint(fmt.Sprintf("%v", r)),
+				Fingerprint:      helpers.ComputeFingerprint(fmt.Sprintf("%s - %s", r["Vulnerabilities"], r["Max. Severity"])),
 				AffectedResource: fmt.Sprintf("%s:%s", r["Ecosystem"], r["Dependency"]),
 				Score:            scoreSeverity(r["Max. Severity"]),
 				Labels:           []string{"potential", "dependency", "code", "github"},


### PR DESCRIPTION
* Expands the `Vulnerable Code Dependencies in Github Repository` vulnerability's resources table into individual vulnerabilities, so they can be individually actioned
* Calculates the fingerprint of each vulnerability so actions applied to them can be dismissed if the context changes (e.g. new CVEs published for the affected package)
* Adds labels to the vulnerabilities, mostly to indicate that they are potential issues because the check doesn't have enough context of the level of exposure