### PR TITLE
Add phpMyAdmin regex to exposed-http-resources

### DIFF
--- a/cmd/vulcan-exposed-http-resources/resources.yaml
+++ b/cmd/vulcan-exposed-http-resources/resources.yaml
@@ -361,6 +361,7 @@
   - "phpMyAdmin-3.3.4/"
   - "phpMyAdmin-3/"
   - "phpMyAdmin-4/"
+  regex: "phpMyAdmin"
   status: 200
   severity: 8.9
   description: Potentially exposed MySQL management page.


### PR DESCRIPTION
Increase confidence of the resource by checking for the `phpMyAdmin` string in the response, usually present in the title and other parts of the body.