### PR TITLE
Expand vulcan-exposed-http-resources vulnerabilities and add labels

### DIFF
--- a/cmd/vulcan-exposed-http-resources/main.go
+++ b/cmd/vulcan-exposed-http-resources/main.go
@@ -236,10 +236,15 @@ func main() {
 			v := exposedVuln
 			v.AffectedResource = resource["URL"]
 			v.Labels = []string{"issue", "http"}
+
+			// Deleting the URL from the resources table because it's already
+			// shown in the AffectedResource attribute.
+			delete(resource, "URL")
+
 			v.Resources = []report.ResourcesGroup{
 				report.ResourcesGroup{
 					Name:   "Exposed Resources",
-					Header: []string{"Score", "Severity", "Confidence", "Description", "URL"},
+					Header: []string{"Score", "Severity", "Confidence", "Description"},
 					Rows:   []map[string]string{resource},
 				},
 			}


### PR DESCRIPTION
* Expands the `Exposed HTTP Resources` vulnerability's resources table into individual vulnerabilities, so they can be individually actioned
* Calculates the fingerprint of each vulnerability so actions applied to them can be dismissed if the context changes (e.g. the confidence of the finding has changed)
* Adds labels to the vulnerabilities, mostly to indicate that they are issues because the check has done some dynamic tests to check it
* Discards vulnerabilities with not `HIGH` confidence