### PR TITLE
Expand vulcan-nessus vulnerabilities and add labels

### DIFF
--- a/cmd/vulcan-nessus/nessus.go
+++ b/cmd/vulcan-nessus/nessus.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -388,7 +387,7 @@ func (r *runner) translateFromNessusToVulcan(hostID int64, target string, nessus
 		} else {
 			vulcanVulnerability.Labels = append(vulcanVulnerability.Labels, "issue")
 		}
-		vulcanVulnerability.ID = computeVulnerabilityID(target, target, vulcanVulnerability.Score)
+		vulcanVulnerability.Fingerprint = helpers.ComputeFingerprint(vulcanVulnerability.Score)
 
 		return []report.Vulnerability{vulcanVulnerability}, nil
 	}
@@ -413,7 +412,7 @@ func (r *runner) translateFromNessusToVulcan(hostID int64, target string, nessus
 			} else {
 				v.Labels = append(v.Labels, "issue")
 			}
-			v.ID = computeVulnerabilityID(target, target, v.Score, v.Details)
+			v.Fingerprint = helpers.ComputeFingerprint(v.Score, v.Details)
 
 			vulnerabilities = append(vulnerabilities, v)
 
@@ -451,23 +450,11 @@ func (r *runner) translateFromNessusToVulcan(hostID int64, target string, nessus
 			} else {
 				v.Labels = append(v.Labels, "issue")
 			}
-			v.ID = computeVulnerabilityID(target, target, v.Score, v.Details, v.Resources)
+			v.Fingerprint = helpers.ComputeFingerprint(v.Score, v.Details, v.Resources)
 
 			vulnerabilities = append(vulnerabilities, v)
 		}
 	}
 
 	return vulnerabilities, nil
-}
-
-func computeVulnerabilityID(target, affectedResource string, elems ...interface{}) string {
-	h := sha256.New()
-
-	fmt.Fprintf(h, "%s - %s", target, affectedResource)
-
-	for _, e := range elems {
-		fmt.Fprintf(h, " - %v", e)
-	}
-
-	return fmt.Sprintf("%x", h.Sum(nil))
 }


### PR DESCRIPTION
* Expands the resources (i.e. affected ports) of each Nessus vulnerability into individual vulnerabilities, so they can be individually actioned. If a port is not specified by Nessus, use the whole target as the affected resource.
* Calculates the fingerprint of each vulnerability so actions applied to them can be dismissed if the context changes (e.g. the output of the Nessus plugin has changed)
* Adds labels to the vulnerabilities, mostly to indicate that they are issues because the check has done some dynamic tests to check it
* Use the new CVSS v3 Nessus score if available, falling back to the already used CVSS base score.
* Ensure that all the `solution` and `see_also` references provided by Nessus are added to the vulnerability. Before we were adding just the first collection of them.