### PR TITLE
Fix phpMyAdmin regex to not match the URL

### DIFF
--- a/cmd/vulcan-exposed-http-resources/resources.yaml
+++ b/cmd/vulcan-exposed-http-resources/resources.yaml
@@ -361,7 +361,7 @@
   - "phpMyAdmin-3.3.4/"
   - "phpMyAdmin-3/"
   - "phpMyAdmin-4/"
-  regex: "phpMyAdmin"
+  regex: "(pma_username|<title>phpMyAdmin</title>)"
   status: 200
   severity: 8.9
   description: Potentially exposed MySQL management page.


### PR DESCRIPTION
Otherwise pages returning 200 to each of the phpMyAdmin tested URLs will be wrongly reported as vulnerable with high confidence.