### PR TITLE
Remove default branch in seekret

### DIFF
--- a/cmd/vulcan-seekret/main.go
+++ b/cmd/vulcan-seekret/main.go
@@ -130,11 +130,7 @@ func main() {
 		if opt.Branch != "" {
 			co.ReferenceName = plumbing.ReferenceName(path.Join("refs/heads", opt.Branch))
 		}
-		_, err = git.PlainClone(repoPath, false, &git.CloneOptions{
-			URL:   target,
-			Auth:  auth,
-			Depth: opt.Depth,
-		})
+		_, err = git.PlainClone(repoPath, false, &co)
 		if err != nil {
 			return err
 		}

--- a/cmd/vulcan-seekret/main.go
+++ b/cmd/vulcan-seekret/main.go
@@ -30,7 +30,7 @@ import (
 )
 
 type options struct {
-	Depth int `json:"depth"`
+	Depth  int    `json:"depth"`
 	Branch string `json:"branch"`
 }
 
@@ -117,16 +117,23 @@ func main() {
 			return checkstate.ErrAssetUnreachable
 		}
 
-		repoPath := filepath.Join("/tmp", filepath.Base(targetURL.Path))
+		repoPath := filepath.Join(os.TempDir(), "repo")
 		if err := os.Mkdir(repoPath, 0755); err != nil {
 			return err
 		}
 
+		co := git.CloneOptions{
+			URL:   target,
+			Auth:  auth,
+			Depth: opt.Depth,
+		}
+		if opt.Branch != "" {
+			co.ReferenceName = plumbing.ReferenceName(path.Join("refs/heads", opt.Branch))
+		}
 		_, err = git.PlainClone(repoPath, false, &git.CloneOptions{
 			URL:   target,
 			Auth:  auth,
 			Depth: opt.Depth,
-			ReferenceName: plumbing.ReferenceName(path.Join("refs/heads", opt.Branch)),
 		})
 		if err != nil {
 			return err

--- a/cmd/vulcan-seekret/manifest.toml
+++ b/cmd/vulcan-seekret/manifest.toml
@@ -2,4 +2,5 @@ Description = "Finds leaked secrets in a Git repository using Seekret"
 Timeout = 600
 AssetTypes = ["GitRepository"]
 RequiredVars = ["GITHUB_ENTERPRISE_ENDPOINT", "GITHUB_ENTERPRISE_TOKEN"]
+# if branch is empty it will use the reference served by the git server (usually master/main)
 Options = '{"depth": 1, "branch": ""}'

--- a/cmd/vulcan-seekret/manifest.toml
+++ b/cmd/vulcan-seekret/manifest.toml
@@ -2,4 +2,4 @@ Description = "Finds leaked secrets in a Git repository using Seekret"
 Timeout = 600
 AssetTypes = ["GitRepository"]
 RequiredVars = ["GITHUB_ENTERPRISE_ENDPOINT", "GITHUB_ENTERPRISE_TOKEN"]
-Options = '{"depth": 1, "branch": "master"}'
+Options = '{"depth": 1, "branch": ""}'


### PR DESCRIPTION
- Removes default master branch. To allow the check to use the default ref served by the git server (master, main , ...)
- Use a fixed path for the repo, preventing the issue when the git url doesn't have a path (i.e. http://localhost:port/)
