### PR TITLE
Upgrade trivy

### DIFF
--- a/cmd/vulcan-trivy/Dockerfile
+++ b/cmd/vulcan-trivy/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright 2020 Adevinta
 
-FROM aquasec/trivy:0.5.2 as dependency_builder
+FROM aquasec/trivy:0.21.2 as dependency_builder
 
 ARG TRIVY_CACHE_DIR=trivy_cache
 

--- a/cmd/vulcan-trivy/vulcan-trivy.go
+++ b/cmd/vulcan-trivy/vulcan-trivy.go
@@ -43,6 +43,10 @@ type options struct {
 	Severities    string `json:"severities"`
 }
 
+type Results struct {
+	Results ScanResponse `json:"Results"`
+}
+
 type ScanResponse []struct {
 	Target          string `json:"Target"`
 	Vulnerabilities []struct {
@@ -119,6 +123,7 @@ func run(ctx context.Context, target, assetType, optJSON string, state checkstat
 	triviCmd := "./trivy"
 	triviArgs := []string{
 		"--cache-dir", trivyCachePath,
+		"image",
 		"-f", "json",
 		"-o", reportOutputFile,
 	}
@@ -171,13 +176,13 @@ func run(ctx context.Context, target, assetType, optJSON string, state checkstat
 		return errors.New("trivy report output file read failed")
 	}
 
-	var results ScanResponse
+	var results Results
 	err = json.Unmarshal(byteValue, &results)
 	if err != nil {
 		return errors.New("unmarshal trivy output failed")
 	}
 
-	return processVulns(results, registryEnvDomain, target, state)
+	return processVulns(results.Results, registryEnvDomain, target, state)
 }
 
 func processVulns(results ScanResponse, registryEnvDomain, target string, state checkstate.State) error {


### PR DESCRIPTION
Upgrade to a newer version of Trivy.
This new version detects CVE-2021-44228