### PR TITLE
Add context, labels and fingerprint to ZAP

### DIFF
--- a/cmd/vulcan-zap/zap.go
+++ b/cmd/vulcan-zap/zap.go
@@ -68,6 +68,13 @@ func processAlert(a map[string]interface{}) (report.Vulnerability, error) {
 	}
 	v.Score = riskToScore(risk)
 
+	v.Labels = []string{"web", "zap"}
+	if strings.ToLower(risk) == "informational" {
+		v.Labels = append(v.Labels, "informational")
+	} else {
+		v.Labels = append(v.Labels, "issue")
+	}
+
 	cweID, ok := a["cweid"].(string)
 	if !ok {
 		return report.Vulnerability{}, fmt.Errorf("Error retrieving CWE ID for \"%v\".", v.Summary)

--- a/cmd/vulcan-zap/zap.go
+++ b/cmd/vulcan-zap/zap.go
@@ -116,7 +116,7 @@ func processAlert(a map[string]interface{}) (report.Vulnerability, error) {
 	}
 
 	v.Resources = []report.ResourcesGroup{
-		report.ResourcesGroup{
+		{
 			Name: "Affected Requests",
 			Header: []string{
 				"Method",
@@ -126,11 +126,11 @@ func processAlert(a map[string]interface{}) (report.Vulnerability, error) {
 				"Evidence",
 			},
 			Rows: []map[string]string{
-				map[string]string{
+				{
 					"Method":    resMethod,
 					"URL":       resURL,
 					"Parameter": resParam,
-					"Attack":    resAttack,
+					"Attack":    fmt.Sprintf("```%s```", resAttack),
 					"Evidence":  resEvidence,
 				},
 			},

--- a/cmd/vulcan-zap/zap.go
+++ b/cmd/vulcan-zap/zap.go
@@ -130,7 +130,7 @@ func processAlert(a map[string]interface{}) (report.Vulnerability, error) {
 					"Method":    resMethod,
 					"URL":       resURL,
 					"Parameter": resParam,
-					"Attack":    fmt.Sprintf("```%s```", resAttack),
+					"Attack":    resAttack,
 					"Evidence":  resEvidence,
 				},
 			},


### PR DESCRIPTION
This PR includes 2 main changes:
- Context was created but not passed to the spider neither to the scan process. By passing the context to the spider and the scan processes we ensure the scan reaches the deepness specified by the check options.
- Added labels to improve filtering in the UI and fingerprint to findings to provide more accurate actions on the finding (mainly mark as false positive).