### PR TITLE
Use created context in spider and scan

### DIFF
--- a/cmd/vulcan-zap/main.go
+++ b/cmd/vulcan-zap/main.go
@@ -127,7 +127,7 @@ func main() {
 
 		// Add base URL to the scope.
 		hostnameRegExQuote := strings.Replace(targetURL.Hostname(), `.`, `\.`, -1)
-		includeInContextRegEx := fmt.Sprintf(`http(s)?:\/\/%s.*`, hostnameRegExQuote)
+		includeInContextRegEx := fmt.Sprintf(`http(s)?:\/\/%s\/.*`, hostnameRegExQuote)
 		logger.Printf("include in context regexp: %s", includeInContextRegEx)
 		_, err = client.Context().IncludeInContext(contextName, includeInContextRegEx)
 		if err != nil {


### PR DESCRIPTION
This PR fixes the context misuse.
In fact, the context is created at the beginning of the process but is not passed to the spider actions nor to the scan action and therefore the only URL/Path scanned were the ones resolved by the [recurse option](https://www.zaproxy.org/docs/api/#ascanactionscan) and the target URL provided.
I would appreciate a careful review on the changes.