### PR TITLE
Add additional zap options

### DIFF
--- a/cmd/vulcan-zap/main.go
+++ b/cmd/vulcan-zap/main.go
@@ -170,16 +170,17 @@ func main() {
 			return fmt.Errorf("error disabling scanners for passive scan: %w", err)
 		}
 
-		logger.Printf("Running spider %v levels deep...", opt.Depth)
-
 		client.Spider().SetOptionMaxDepth(opt.Depth)
 		if err != nil {
-			return fmt.Errorf("error setting max depth: %w", err)
+			return fmt.Errorf("error setting spider max depth: %w", err)
 		}
 		client.Spider().SetOptionMaxDuration(opt.MaxSpiderDuration)
 		if err != nil {
-			return fmt.Errorf("error setting max duration: %w", err)
+			return fmt.Errorf("error setting spider max duration: %w", err)
 		}
+
+		logger.Printf("Running spider %v levels deep, max duration %v, ...", opt.Depth, opt.MaxSpiderDuration)
+
 		resp, err := client.Spider().Scan(targetURL.String(), "", contextName, "", "")
 		if err != nil {
 			return fmt.Errorf("error executing the spider: %w", err)
@@ -251,10 +252,15 @@ func main() {
 		}
 		logger.Printf("Spider found the following URLs: %+v", resp)
 
-		logger.Printf("Running AJAX spider %v levels deep...", opt.Depth)
+		client.AjaxSpider().SetOptionMaxDuration(opt.MaxSpiderDuration)
+		if err != nil {
+			return fmt.Errorf("error setting ajax spider max duration: %w", err)
+		}
+
+		logger.Printf("Running AJAX spider %v levels deep, max duration %v...", opt.Depth, opt.MaxSpiderDuration)
 
 		client.AjaxSpider().SetOptionMaxCrawlDepth(opt.Depth)
-		resp, err = client.AjaxSpider().Scan(targetURL.String(), "", contextName, "")
+		_, err = client.AjaxSpider().Scan(targetURL.String(), "", contextName, "")
 		if err != nil {
 			return fmt.Errorf("error executing the AJAX spider: %w", err)
 		}

--- a/cmd/vulcan-zap/main.go
+++ b/cmd/vulcan-zap/main.go
@@ -29,7 +29,6 @@ var (
 	checkName = "vulcan-zap"
 	logger    = check.NewCheckLog(checkName)
 	client    zap.Interface
-	err       error
 )
 
 const (
@@ -170,11 +169,11 @@ func main() {
 			return fmt.Errorf("error disabling scanners for passive scan: %w", err)
 		}
 
-		client.Spider().SetOptionMaxDepth(opt.Depth)
+		_, err = client.Spider().SetOptionMaxDepth(opt.Depth)
 		if err != nil {
 			return fmt.Errorf("error setting spider max depth: %w", err)
 		}
-		client.Spider().SetOptionMaxDuration(opt.MaxSpiderDuration)
+		_, err = client.Spider().SetOptionMaxDuration(opt.MaxSpiderDuration)
 		if err != nil {
 			return fmt.Errorf("error setting spider max duration: %w", err)
 		}
@@ -252,7 +251,7 @@ func main() {
 		}
 		logger.Printf("Spider found the following URLs: %+v", resp)
 
-		client.AjaxSpider().SetOptionMaxDuration(opt.MaxSpiderDuration)
+		_, err = client.AjaxSpider().SetOptionMaxDuration(opt.MaxSpiderDuration)
 		if err != nil {
 			return fmt.Errorf("error setting ajax spider max duration: %w", err)
 		}

--- a/cmd/vulcan-zap/manifest.toml
+++ b/cmd/vulcan-zap/manifest.toml
@@ -6,4 +6,14 @@ Timeout = 36000 # 10 hours. Expressed in seconds as an integer.
 # 10003 - Vulnerable JS Library - Duplicates the Retire.js check.
 # 10108 - Reverse Tabnabbing - Not relevant for modern browser versions.
 # Source: https://www.zaproxy.org/docs/alerts/
-Options = '{"depth": 2, "active": true, "min_score": 0, "disabled_scanners": ["10062", "10003", "10108"]}'
+Options = """{
+    "depth": 2, 
+    "active": true, 
+    "min_score": 0, 
+    "disabled_scanners": ["10062", "10003", "10108"],
+    "max_spider_duration": 0,
+    "max_scan_duration": 0, 
+    "max_rule_duration": 0,
+    "openapi_url": "",
+    "openapi_host": ""
+    }"""


### PR DESCRIPTION
Add new options for Vulcan-zap:

- max_spider_duration: Applies to both normal an Ajax spiders.
- max_scan_duration: Limits the total amount of time spent in all the rules.
- max_rule_duration: Limits the time spent in one rule.
- openapi_url: Allows to specify a Openapi/swagger url.
- openapi_host: Used with the previous one.
