### PR TITLE
Expand vulcan-exposed-rdp vulnerabilities and add labels

### DIFF
--- a/cmd/vulcan-exposed-rdp/main.go
+++ b/cmd/vulcan-exposed-rdp/main.go
@@ -122,7 +122,7 @@ func isExposedRDP(host, port string, timeout int) []report.Vulnerability {
 	if CCPDURegex.Match(b) && b[5] == byte('\xd0') {
 		exposedRDP.Details += fmt.Sprintf("RDP host detected in port: %s", port)
 		exposedRDP.AffectedResource = fmt.Sprintf("%s", port)
-		exposedRDP.ID = helpers.ComputeFingerprint()
+		exposedRDP.Fingerprint = helpers.ComputeFingerprint()
 		exposedRDP.Labels = []string{"issue", "rdp"}
 		return []report.Vulnerability{exposedRDP}
 	}

--- a/cmd/vulcan-exposed-rdp/main.go
+++ b/cmd/vulcan-exposed-rdp/main.go
@@ -121,7 +121,7 @@ func isExposedRDP(host, port string, timeout int) []report.Vulnerability {
 
 	if CCPDURegex.Match(b) && b[5] == byte('\xd0') {
 		exposedRDP.Details += fmt.Sprintf("RDP host detected in port: %s", port)
-		exposedRDP.AffectedResource = fmt.Sprintf("%s/rdp", port)
+		exposedRDP.AffectedResource = fmt.Sprintf("%s/tcp", port)
 		exposedRDP.Fingerprint = helpers.ComputeFingerprint()
 		exposedRDP.Labels = []string{"issue", "rdp"}
 		return []report.Vulnerability{exposedRDP}

--- a/cmd/vulcan-exposed-rdp/main.go
+++ b/cmd/vulcan-exposed-rdp/main.go
@@ -121,7 +121,7 @@ func isExposedRDP(host, port string, timeout int) []report.Vulnerability {
 
 	if CCPDURegex.Match(b) && b[5] == byte('\xd0') {
 		exposedRDP.Details += fmt.Sprintf("RDP host detected in port: %s", port)
-		exposedRDP.AffectedResource = fmt.Sprintf("%s", port)
+		exposedRDP.AffectedResource = fmt.Sprintf("%s/rdp", port)
 		exposedRDP.Fingerprint = helpers.ComputeFingerprint()
 		exposedRDP.Labels = []string{"issue", "rdp"}
 		return []report.Vulnerability{exposedRDP}

--- a/cmd/vulcan-exposed-rdp/main.go
+++ b/cmd/vulcan-exposed-rdp/main.go
@@ -7,7 +7,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
@@ -123,23 +122,12 @@ func isExposedRDP(host, port string, timeout int) []report.Vulnerability {
 	if CCPDURegex.Match(b) && b[5] == byte('\xd0') {
 		exposedRDP.Details += fmt.Sprintf("RDP host detected in port: %s", port)
 		exposedRDP.AffectedResource = fmt.Sprintf("%s", port)
-		exposedRDP.ID = computeVulnerabilityID(host, exposedRDP.AffectedResource, port)
+		exposedRDP.ID = helpers.ComputeFingerprint()
 		exposedRDP.Labels = []string{"issue", "rdp"}
 		return []report.Vulnerability{exposedRDP}
 	}
 
 	return nil
-}
-
-func computeVulnerabilityID(target, affectedResource string, elems ...interface{}) string {
-	h := sha256.New()
-
-	fmt.Fprintf(h, "%s - %s", target, affectedResource)
-
-	for _, e := range elems {
-		fmt.Fprintf(h, " - %v", e)
-	}
-	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
 func run(ctx context.Context, target, assetType, optJSON string, state checkstate.State) (err error) {


### PR DESCRIPTION
- Adapt to the affected resources model
- Calculates the fingerprint of each vulnerability so actions applied to them can be dismissed if the context changes
- Adds labels to the vulnerabilities