### PR TITLE
Expand vulcan-exposed-db vulnerabilities and add labels

### DIFF
--- a/cmd/vulcan-exposed-db/main.go
+++ b/cmd/vulcan-exposed-db/main.go
@@ -6,9 +6,7 @@ package main
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/json"
-	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -96,23 +94,12 @@ func exposedDatabases(target string, nmapReport *gonmap.NmapRun, databaseRegex *
 			gr.Rows = append(gr.Rows, networkResource)
 			v := exposedVuln
 			v.Resources = []report.ResourcesGroup{gr}
-			v.ID = computeVulnerabilityID(target, v.AffectedResource, port.PortId, port.Protocol, port.Service.Product, port.Service.Version)
+			v.Fingerprint = helpers.ComputeFingerprint(port.Service.Product, port.Service.Version)
 			v.Labels = []string{"issue", "db"}
 			vulns = append(vulns, v)
 		}
 	}
 	return vulns
-}
-
-func computeVulnerabilityID(target, affectedResource string, elems ...interface{}) string {
-	h := sha256.New()
-
-	fmt.Fprintf(h, "%s - %s", target, affectedResource)
-
-	for _, e := range elems {
-		fmt.Fprintf(h, " - %v", e)
-	}
-	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
 func main() {

--- a/cmd/vulcan-exposed-db/main.go
+++ b/cmd/vulcan-exposed-db/main.go
@@ -7,6 +7,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -94,6 +95,7 @@ func exposedDatabases(target string, nmapReport *gonmap.NmapRun, databaseRegex *
 			gr.Rows = append(gr.Rows, networkResource)
 			v := exposedVuln
 			v.Resources = []report.ResourcesGroup{gr}
+			v.AffectedResource = fmt.Sprintf("%d/%s", port.PortId, port.Protocol)
 			v.Fingerprint = helpers.ComputeFingerprint(port.Service.Product, port.Service.Version)
 			v.Labels = []string{"issue", "db"}
 			vulns = append(vulns, v)


### PR DESCRIPTION
- Expands the Exposed DB vulnerability's resources table into individual vulnerabilities, so they can be individually actioned
- Calculates the fingerprint of each vulnerability so actions applied to them can be dismissed if the context changes
- Adds labels to the vulnerabilities