### PR TITLE
Migrate vulcan-retirejs check to v2

### DIFF
--- a/cmd/vulcan-retirejs/main.go
+++ b/cmd/vulcan-retirejs/main.go
@@ -73,7 +73,6 @@ func scanTarget(ctx context.Context, target, assetType string, logger *logrus.En
 	target, err := resolveTarget(target, assetType)
 	if err != nil {
 		// Don't fail the check if the target can not be accessed.
-		// It shouldn't reach here due to previous check with helpers.IsReachable().
 		if _, ok := err.(*url.Error); ok {
 			return nil
 		}

--- a/cmd/vulcan-retirejs/main.go
+++ b/cmd/vulcan-retirejs/main.go
@@ -128,7 +128,7 @@ func addVulnsToState(state checkstate.State, r []RetireJsFileResult) {
 					"Additional vulnerability information can be found in the links in the resources table.",
 				},
 				References:       []string{"https://portswigger.net/kb/issues/00500080_vulnerable-javascript-dependency"},
-				AffectedResource: fmt.Sprintf("%s-%s", v.Component, v.Version), // example: jquery-1.9.0
+				AffectedResource: fmt.Sprintf("%s-%s", v.Component, v.Version), // Example: jquery-1.9.0.
 				Score:            0.0,
 				Resources: []report.ResourcesGroup{
 					{
@@ -182,7 +182,7 @@ func addVulnsToState(state checkstate.State, r []RetireJsFileResult) {
 			// - Store the severity for each of the vulnerabilities
 			// - Store the CVEs, IssueID and BugID for each of the vulnerabilities
 			// - Sort the slice and join the elements with a field separator
-			// A change on any of these values may generate a new fingerprint
+			// A change on any of these values may generate a new fingerprint.
 			sort.Strings(fingerprint)
 			vulnerability.Fingerprint = helpers.ComputeFingerprint(strings.Join(fingerprint, "|"))
 			state.AddVulnerabilities(vulnerability)

--- a/cmd/vulcan-retirejs/main.go
+++ b/cmd/vulcan-retirejs/main.go
@@ -7,7 +7,6 @@ package main
 import (
 	"context"
 	"crypto/tls"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -38,6 +37,7 @@ var (
 	logger     = check.NewCheckLog(checkName)
 	retireArgs = []string{
 		"retire",
+		"--exitwith", "0",
 		"--js",
 		"--outputformat", "json",
 		"--jspath", jsPath,
@@ -105,16 +105,8 @@ func runRetireJs(ctx context.Context, args []string) ([]RetireJsFileResult, erro
 		args = retireArgs
 	}
 	var report RetireJsReport
-	noFindings, findings, _, err := command.ExecuteWithStdErr(ctx, logger, args[0], args[1:]...)
-	if err != nil {
-		return report.Data, err
-	}
+	_, err := command.ExecuteAndParseJSON(ctx, logger, &report, args[0], args[1:]...)
 
-	if len(findings) > 0 {
-		err = json.Unmarshal(findings, &report)
-	} else {
-		err = json.Unmarshal(noFindings, &report)
-	}
 	return report.Data, err
 }
 

--- a/cmd/vulcan-retirejs/main.go
+++ b/cmd/vulcan-retirejs/main.go
@@ -134,7 +134,6 @@ func addVulnsToState(state checkstate.State, r []RetireJsFileResult) {
 					{
 						Name: "Vulnerabilities",
 						Header: []string{
-							"Dependency",
 							"CVEs",
 							"Affected Versions",
 							"Severity",
@@ -166,7 +165,6 @@ func addVulnsToState(state checkstate.State, r []RetireJsFileResult) {
 				}
 				gr := vulnerability.Resources[0]
 				r := map[string]string{
-					"Dependency":        vulnerability.AffectedResource,
 					"CVEs":              strings.Join(i.Identifiers.Cve, ", "),
 					"Affected Versions": getAffectedVersion(i.AtOrAbove, i.Below),
 					"Severity":          strings.ToLower(i.Severity),

--- a/cmd/vulcan-retirejs/main.go
+++ b/cmd/vulcan-retirejs/main.go
@@ -193,10 +193,12 @@ func getScore(severity string) float32 {
 }
 
 type RetireJsReport struct {
-	Version string               `json:"version"`
-	Start   time.Time            `json:"start"`
-	Data    []RetireJsFileResult `json:"data"`
-	Time    float64              `json:"time"`
+	Data     []RetireJsFileResult          `json:"data"`
+	Errors   []map[interface{}]interface{} `json:"errors"`
+	Messages []map[interface{}]interface{} `json:"messages"`
+	Start    time.Time                     `json:"start"`
+	Time     float64                       `json:"time"`
+	Version  string                        `json:"version"`
 }
 
 type RetireJsFileResult struct {
@@ -205,21 +207,25 @@ type RetireJsFileResult struct {
 }
 
 type RetireJsResult struct {
-	Version         string `json:"version"`
 	Component       string `json:"component"`
 	Detection       string `json:"detection"`
+	Version         string `json:"version"`
 	Vulnerabilities []RetireJsVulnerability
 }
 
 type RetireJsResultId struct {
-	Issue   string `json:"issue"`
-	Summary string `json:"summary"`
+	Cve     []string `json:"CVE"`
+	Bug     string   `json:"bug"`
+	Issue   string   `json:"issue"`
+	Summary string   `json:"summary"`
 }
 
 type RetireJsVulnerability struct {
+	AtOrAbove   string           `json:"atOrAbove"`
+	Below       string           `json:"below"`
+	Identifiers RetireJsResultId `json:"identifiers"`
 	Info        []string         `json:"info"`
 	Severity    string           `json:"severity"`
-	Identifiers RetireJsResultId `json:"identifiers"`
 }
 
 func findScriptFiles(target string) (int, error) {

--- a/cmd/vulcan-retirejs/main.go
+++ b/cmd/vulcan-retirejs/main.go
@@ -36,7 +36,13 @@ const (
 var (
 	checkName  = "vulcan-retirejs"
 	logger     = check.NewCheckLog(checkName)
-	retireArgs = []string{"retire", "--outputformat", "json", "--jspath", jsPath, "--jsrepo", "jsrepository.json"}
+	retireArgs = []string{
+		"retire",
+		"--js",
+		"--outputformat", "json",
+		"--jspath", jsPath,
+		"--jsrepo", "jsrepository.json",
+	}
 )
 
 func main() {

--- a/cmd/vulcan-retirejs/main.go
+++ b/cmd/vulcan-retirejs/main.go
@@ -176,6 +176,7 @@ func addVulnsToState(state checkstate.State, r []RetireJsFileResult) {
 }
 
 func getScore(severity string) float32 {
+	severity = strings.ToLower(severity)
 	if severity == "critical" {
 		return report.SeverityThresholdCritical
 	}

--- a/cmd/vulcan-retirejs/main.go
+++ b/cmd/vulcan-retirejs/main.go
@@ -146,8 +146,8 @@ func addVulnsToState(state checkstate.State, r []RetireJsFileResult) {
 			details := []string{"The following vulnerabilities were found in the vulnerable JavaScript dependency:"}
 			fingerprint = append(fingerprint, fmt.Sprintf("vulnerabilities#%d", len(v.Vulnerabilities)))
 			for _, i := range v.Vulnerabilities {
-				if vulnerability.Score < getScore(i.Severity) {
-					vulnerability.Score = getScore(i.Severity)
+				if score := getScore(i.Severity); vulnerability.Score < score {
+					vulnerability.Score = score
 				}
 				fingerprint = append(fingerprint, strings.ToLower(i.Severity))
 				if i.Identifiers.Bug != "" {

--- a/cmd/vulcan-retirejs/main.go
+++ b/cmd/vulcan-retirejs/main.go
@@ -416,7 +416,7 @@ func resolveTarget(target, assetType string) (string, error) {
 			return "", err
 		}
 		return resp.Request.URL.String(), nil
+	default:
+		return "", errors.New("unexpected assettype provided")
 	}
-
-	return "", errors.New("unexpected assettype provided")
 }

--- a/cmd/vulcan-retirejs/main.go
+++ b/cmd/vulcan-retirejs/main.go
@@ -134,16 +134,16 @@ func addVulnsToState(state checkstate.State, r []RetireJsFileResult) {
 					{
 						Name: "Vulnerabilities",
 						Header: []string{
-							"Summary",
+							"Dependency",
+							"CVEs",
 							"Affected Versions",
 							"Severity",
-							"CVEs",
 							"References",
 						},
 					},
 				},
 			}
-			details := []string{"The following vulnerabilities were found in the vulnerable JavaScript dependency:"}
+			details := []string{fmt.Sprintf("The following vulnerabilities were found in %s version %s JavaScript dependency:", v.Component, v.Version)}
 			fingerprint = append(fingerprint, fmt.Sprintf("vulnerabilities#%d", len(v.Vulnerabilities)))
 			for _, i := range v.Vulnerabilities {
 				if score := getScore(i.Severity); vulnerability.Score < score {
@@ -156,7 +156,7 @@ func addVulnsToState(state checkstate.State, r []RetireJsFileResult) {
 				if i.Identifiers.Issue != "" {
 					fingerprint = append(fingerprint, i.Identifiers.Issue)
 				}
-				details = append(details, fmt.Sprintf("* %s", i.Identifiers.Summary))
+				details = append(details, fmt.Sprintf("- [%s] %s", strings.Join(i.Identifiers.Cve, ","), i.Identifiers.Summary))
 				references := ""
 				for i, reference := range i.Info {
 					if i > 0 {
@@ -166,9 +166,9 @@ func addVulnsToState(state checkstate.State, r []RetireJsFileResult) {
 				}
 				gr := vulnerability.Resources[0]
 				r := map[string]string{
-					"Summary":           i.Identifiers.Summary,
-					"Affected Versions": getAffectedVersion(i.AtOrAbove, i.Below),
+					"Dependency":        vulnerability.AffectedResource,
 					"CVEs":              strings.Join(i.Identifiers.Cve, ", "),
+					"Affected Versions": getAffectedVersion(i.AtOrAbove, i.Below),
 					"Severity":          strings.ToLower(i.Severity),
 					"References":        references,
 				}

--- a/cmd/vulcan-retirejs/main_test.go
+++ b/cmd/vulcan-retirejs/main_test.go
@@ -264,6 +264,13 @@ func TestResolveWebAddress(t *testing.T) {
 	}
 }
 
+func TestResolveUnexpectedAssettype(t *testing.T) {
+	_, err := resolveTarget("http://www.example.com", "Unexpected")
+	if err == nil {
+		t.Fatalf("An 'unexpected assettype provided' error was expected")
+	}
+}
+
 func TestAddVulnsToState(t *testing.T) {
 	retireJsVulnerability := RetireJsVulnerability{
 		Info:        []string{"https://bugs.jquery.com/ticket/11974", "http://research.insecurelabs.org/jquery/test/"},

--- a/cmd/vulcan-retirejs/main_test.go
+++ b/cmd/vulcan-retirejs/main_test.go
@@ -226,7 +226,11 @@ func TestResolveTarget(t *testing.T) {
 }
 
 func TestAddVulnsToState(t *testing.T) {
-	retireJsVulnerability := RetireJsVulnerability{[]string{"https://bugs.jquery.com/ticket/11974", "http://research.insecurelabs.org/jquery/test/"}, "high", RetireJsResultId{"Issue-123", "Summary text here"}}
+	retireJsVulnerability := RetireJsVulnerability{
+		Info:        []string{"https://bugs.jquery.com/ticket/11974", "http://research.insecurelabs.org/jquery/test/"},
+		Severity:    "high",
+		Identifiers: RetireJsResultId{Issue: "Issue-123", Summary: "Summary text here"},
+	}
 	retireJsResult := RetireJsResult{"1.10.2", "jquery", "detection", []RetireJsVulnerability{retireJsVulnerability}}
 	retireJsFileResult := RetireJsFileResult{"file", []RetireJsResult{retireJsResult}}
 	p := stateMock{}

--- a/cmd/vulcan-retirejs/main_test.go
+++ b/cmd/vulcan-retirejs/main_test.go
@@ -216,7 +216,7 @@ func TestResolveTarget(t *testing.T) {
 		}
 	}))
 	defer ts.Close()
-	targetResolved, _ := resolveTarget(strings.TrimLeft(ts.URL, "http://"))
+	targetResolved, _ := resolveTarget(strings.TrimLeft(ts.URL, "http://"), "Hostname")
 	targetExpected := ts.URL + "/landing-page/?n=1"
 
 	if targetResolved != ts.URL+"/landing-page/?n=1" {
@@ -272,12 +272,13 @@ func TestScanTarget(t *testing.T) {
 	}
 
 	target := u.Host
+	assetType := "Hostname"
 	ctx := context.Background()
 	args := []string{"echo", mockRetireOutput}
 
 	l := check.NewCheckLog(checkName)
 	var state state.State
-	err = scanTarget(ctx, target, l, state, args)
+	err = scanTarget(ctx, target, assetType, l, state, args)
 	if err != nil {
 		t.Fatalf("Error when running scanTarget: %v", err)
 	}

--- a/cmd/vulcan-retirejs/manifest.toml
+++ b/cmd/vulcan-retirejs/manifest.toml
@@ -1,2 +1,2 @@
-Description = "Checks web pages for vulnerable JavaScript libraries"
-AssetTypes = ["Hostname"]
+Description = "Check web pages for vulnerable JavaScript libraries"
+AssetTypes = ["Hostname", "WebAddress"]


### PR DESCRIPTION
This PR includes the following changes:
- It now accept Hostname andWebAddress as target asset types. Before only Hostnames were accepted.
- Aggregating vulnerabilities for the same affected resource and generating a proper fingerprint (in the same way Github Alerts and Trivy checks are doing).
- Some changes done in how retire command runs and how to parse the results in order to workaround [retire.js issue 356](https://github.com/RetireJS/retire.js/issues/356).