### PR TITLE
Migrate vulcan-s3-takeover to v2

### DIFF
--- a/cmd/vulcan-s3-takeover/local.toml.example
+++ b/cmd/vulcan-s3-takeover/local.toml.example
@@ -1,3 +1,5 @@
 [Check]
 Target = "example.com"
 AssetType = "Hostname"
+
+# To test use ${RANDOM_NAME}.s3-website-eu-west-1.amazonaws.com as target

--- a/cmd/vulcan-s3-takeover/manifest.toml
+++ b/cmd/vulcan-s3-takeover/manifest.toml
@@ -1,2 +1,2 @@
 Description = "Checks if an asset is vulnerable to S3 subdomain takeover"
-AssetTypes = ["Hostname"]
+AssetTypes = ["Hostname", "WebAddress"]


### PR DESCRIPTION
Modifications conducted:
* The check now can be used against `Hostname` or `WebAddress`
* For the case of a `Hostname`, both `http` and `https` are tested
* The affected resource is the resolved target (i.e. the target itself in case of `WebAddress` and the generated `http` and `https` URLs for `Hostname`)
* The findings are labeled as `issue`
* The bucket name is used to calculate the fingerprint

To test a `Hostname` use `${RANDOM_NAME}.s3-website-eu-west-1.amazonaws.com` as the target.
To test a `WebAddres` use `http://${RANDOM_NAME}.s3-website-eu-west-1.amazonaws.com` as the target.
To test the `https` and/or the `application/xml` flows, you can create a CloudFront distribution pointing to a S3 static web-hosting. I have one created to show the behaviour during the code review. 