### PR TITLE
Migrate vulcan-heartbleed to v2

### DIFF
--- a/cmd/vulcan-heartbleed/main.go
+++ b/cmd/vulcan-heartbleed/main.go
@@ -36,7 +36,10 @@ var (
 			"http://heartbleed.com/",
 			"https://en.wikipedia.org/wiki/Heartbleed",
 		},
-		Recommendations: []string{"Upgrade OpenSSL to, at least, 1.0.2h or 1.0.1t"},
+		Recommendations:  []string{"Upgrade OpenSSL to, at least, 1.0.2h or 1.0.1t"},
+		Labels:           []string{"issue", "ssl"},
+		AffectedResource: "443/tcp",
+		Fingerprint:      helpers.ComputeFingerprint(),
 	}
 )
 
@@ -50,7 +53,6 @@ func testHeartbleed(host string) (string, error) {
 }
 
 func main() {
-
 	run := func(ctx context.Context, target, assetType, optJSON string, state checkstate.State) (err error) {
 		if target == "" {
 			return errors.New("check target missing")


### PR DESCRIPTION
* Labels the finding as issue
* Uses port 443/tcp as affected resource
* Uses an empty fingerprint

Execution example:
```
...
        ResultData: report.ResultData{
            Vulnerabilities: {
                {
                    ID:                     "",
                    Summary:                "Heartbleed",
                    Score:                  8.899999618530273,
                    AffectedResource:       "443/tcp",
                    AffectedResourceString: "",
                    Fingerprint:            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                    CWEID:                  0x77,
                    Description:            "OpenSSL versions 1.0.1 through 1.0.1f contain a flaw in its implementation of the TLS/DTLS heartbeat functionality.This flaw allows an attacker to retrieve private memory of an application that uses the vulnerable OpenSSL library in chunks of  64k at a time. Note that an attacker can repeatedly leverage the vulnerability to retrieve as many 64k chunks of memory as are necessary to retrieve the intended secrets",
                    Details:                "",
                    ImpactDetails:          "An attacker may be able to execute arbitrary code, alter the intended control flow, read sensitive information, or cause the system to crash.",
                    Labels:                 {"issue", "ssl"},
                    Recommendations:        {"Upgrade OpenSSL to, at least, 1.0.2h or 1.0.1t"},
                    References:             {"http://heartbleed.com/", "https://en.wikipedia.org/wiki/Heartbleed"},
                    Resources:              nil,
                    Attachments:            nil,
                    Vulnerabilities:        nil,
                },
            },
            Data:          {...
```