### PR TITLE
Upgrade trivy

### DIFF
--- a/cmd/vulcan-trivy/Dockerfile
+++ b/cmd/vulcan-trivy/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright 2020 Adevinta
 
-FROM aquasec/trivy:0.24.4 as dependency_builder
+FROM aquasec/trivy:0.28.0 as dependency_builder
 
 ENV TRIVY_CACHE_DIR=/trivy_cache
 

--- a/cmd/vulcan-trivy/Dockerfile
+++ b/cmd/vulcan-trivy/Dockerfile
@@ -1,18 +1,18 @@
 # Copyright 2020 Adevinta
 
-FROM aquasec/trivy:0.21.2 as dependency_builder
+FROM aquasec/trivy:0.24.4 as dependency_builder
 
-ARG TRIVY_CACHE_DIR=trivy_cache
+ENV TRIVY_CACHE_DIR=/trivy_cache
 
 RUN mkdir $TRIVY_CACHE_DIR && \
-    trivy --quiet --download-db-only --cache-dir $TRIVY_CACHE_DIR/ && \
-    tar cvfz trivy_cache.tgz $TRIVY_CACHE_DIR
+    trivy --quiet image --download-db-only && \
+    tar cvfz trivy_cache.tgz ${TRIVY_CACHE_DIR}
 
 FROM alpine
 # Required for scanning RHEL/CentOS images
 RUN apk add rpm
 WORKDIR /
+ENV TRIVY_CACHE_DIR=/trivy_cache
 COPY --from=dependency_builder /usr/local/bin/trivy trivy_cache.tgz /
-COPY ./vulcan-trivy /
-COPY entrypoint.sh /
+COPY ./vulcan-trivy entrypoint.sh /
 CMD ["/entrypoint.sh"]

--- a/cmd/vulcan-trivy/Dockerfile
+++ b/cmd/vulcan-trivy/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright 2020 Adevinta
 
-FROM aquasec/trivy:0.28.0 as dependency_builder
+FROM aquasec/trivy:0.28.1 as dependency_builder
 
 ENV TRIVY_CACHE_DIR=/trivy_cache
 

--- a/cmd/vulcan-trivy/vulcan-trivy.go
+++ b/cmd/vulcan-trivy/vulcan-trivy.go
@@ -242,7 +242,7 @@ func processVulns(results ScanResponse, registryEnvDomain, target string, state 
 	vp := report.ResourcesGroup{
 		Name: "Package Vulnerabilities",
 		Header: []string{
-			"FixedBy",
+			"Fixed Version",
 			"Vulnerabilities",
 			"Severity",
 			"CWEs",
@@ -272,7 +272,7 @@ func processVulns(results ScanResponse, registryEnvDomain, target string, state 
 				maxScore = newScore
 			}
 			row := make(map[string]string, len(vp.Header))
-			row["FixedBy"] = p.fixedBy
+			row["Fixed Version"] = p.fixedBy
 			if p.cwes != nil {
 				urls := []string{}
 				for _, cwe := range p.cwes {
@@ -292,15 +292,15 @@ func processVulns(results ScanResponse, registryEnvDomain, target string, state 
 			Name: "Packages",
 			Header: []string{
 				"Location",
-				"FixedBy",
+				"Min. Recommended Version",
 			},
 			Rows: []map[string]string{},
 		}
 		for path := range det.paths {
 			prg.Rows = append(prg.Rows,
 				map[string]string{
-					"Location": path,
-					"FixedBy":  det.fixedBy,
+					prg.Header[0]: path,
+					prg.Header[1]: det.fixedBy,
 				})
 		}
 

--- a/cmd/vulcan-trivy/vulcan-trivy.go
+++ b/cmd/vulcan-trivy/vulcan-trivy.go
@@ -262,18 +262,20 @@ func processVulns(results scanResponse, registryEnvDomain, target string, state 
 
 		vp.Rows = []map[string]string{}
 		maxScore := getScore("NONE")
-		fingerprint := make([]string, len(l))
+		fingerprint := []string{}
 		for i, p := range l {
 			fingerprint = append(fingerprint, p.cve+p.severity)
+
 			// Compute the fingerprint for all the CVEs but add only vulnCVETruncateLimit to the table
-			if i > vulnCVETruncateLimit {
+			if i >= vulnCVETruncateLimit {
 				continue
 			}
+
 			newScore := getScore(p.severity)
 			if newScore > maxScore {
 				maxScore = newScore
 			}
-			row := make(map[string]string, len(vp.Header))
+			row := map[string]string{}
 			row["Fixed Version"] = p.fixedBy
 			if p.cwes != nil {
 				urls := []string{}
@@ -367,6 +369,7 @@ func getScore(severity string) float32 {
 
 var cveRegex = regexp.MustCompile(`^CVE-(\d{4})-(\d+)$`)
 
+// cve2num returns a numeric representation with year and id in case of CVE or a 0 otherwise
 func cve2num(cve string) int {
 	m := cveRegex.FindStringSubmatch(cve)
 	if len(m) == 3 {

--- a/cmd/vulcan-trivy/vulcan-trivy.go
+++ b/cmd/vulcan-trivy/vulcan-trivy.go
@@ -201,7 +201,8 @@ func processVulns(results scanResponse, registryEnvDomain, target string, state 
 			path := ""
 			switch {
 			case tt.Class == "os-pkgs":
-				path = tt.Type // alpine, centos, ...
+				// Type contains the os distro name (i.e. alpine, centos, amazon, ...)
+				path = fmt.Sprintf("%s:%s", tt.Type, tv.PkgName)
 			case tv.PkgPath != "":
 				path = tv.PkgPath
 			default:
@@ -301,13 +302,13 @@ func processVulns(results scanResponse, registryEnvDomain, target string, state 
 			Details: generateDetails(registryEnvDomain, target),
 			Resources: []report.ResourcesGroup{
 				{
-					Name: "Packages",
+					Name: "Package",
 					Header: []string{
-						"Location",
+						"Package",
 						"Min. Recommended Version",
 					},
 					Rows: []map[string]string{{
-						"Location":                 key.path,
+						"Package":                  key.path,
 						"Min. Recommended Version": det.fixedBy,
 					}},
 				},

--- a/cmd/vulcan-trivy/vulcan-trivy.go
+++ b/cmd/vulcan-trivy/vulcan-trivy.go
@@ -151,6 +151,8 @@ func run(ctx context.Context, target, assetType, optJSON string, state checkstat
 		severitiesFlag := []string{"--severity", opt.Severities}
 		triviArgs = append(triviArgs, severitiesFlag...)
 	}
+	// Restrict to vulnerabilities (no config/secrets yet)
+	triviArgs = append(triviArgs, "--security-checks", "vuln")
 	// Append the target (docker image including registry hostname).
 	triviArgs = append(triviArgs, target)
 

--- a/cmd/vulcan-trivy/vulcan-trivy.go
+++ b/cmd/vulcan-trivy/vulcan-trivy.go
@@ -285,31 +285,27 @@ func processVulns(results ScanResponse, registryEnvDomain, target string, state 
 			row["Severity"] = p.severity
 			vp.Rows = append(vp.Rows, row)
 		}
-		af := strings.TrimSpace(fmt.Sprintf("%s:%s", key.name, key.version))
 
 		ids := []string{}
 		for path := range det.paths {
-			ids = append(ids, fmt.Sprintf("Path: %s", path))
+			ids = append(ids, fmt.Sprintf("Location: %s", path))
 		}
-
-		var rec string
 		if det.fixedBy != "" {
-			rec = fmt.Sprintf("Upgrade %s to %s or newer.", af, det.fixedBy)
-		} else {
-			// this should't happen
-			rec = fmt.Sprintf("Upgrade %s to newer versions.", af)
+			ids = append(ids, fmt.Sprintf("Fixed by: %s", det.fixedBy))
 		}
 
 		// Build the vulnerability.
 		vuln := report.Vulnerability{
 			// Issue attributes.
-			AffectedResource: af,
+			AffectedResource: strings.TrimSpace(fmt.Sprintf("%s:%s", key.name, key.version)),
 			Fingerprint:      helpers.ComputeFingerprint(det.paths, fingerprint),
 			Summary:          "Outdated Packages in Docker Image",
 			Description:      "Vulnerabilities have been found in outdated packages installed in the Docker image.",
-			Recommendations:  []string{rec},
-			CWEID:            937,
-			Labels:           []string{"potential", "docker"},
+			Recommendations: []string{
+				"Update affected packages to the versions specified in the resources table or newer.",
+			},
+			CWEID:  937,
+			Labels: []string{"potential", "docker"},
 			// Finding attributes.
 			Score:         maxScore,
 			Details:       generateDetails(registryEnvDomain, target),

--- a/cmd/vulcan-trivy/vulcan-trivy.go
+++ b/cmd/vulcan-trivy/vulcan-trivy.go
@@ -291,6 +291,9 @@ func processVulns(results scanResponse, registryEnvDomain, target string, state 
 			vp.Rows = append(vp.Rows, row)
 		}
 
+		// Ensure the order is not relevant.
+		sort.Strings(fingerprint)
+
 		// Build the vulnerability.
 		state.AddVulnerabilities(report.Vulnerability{
 			// Issue attributes.

--- a/cmd/vulcan-trivy/vulcan-trivy.go
+++ b/cmd/vulcan-trivy/vulcan-trivy.go
@@ -95,17 +95,13 @@ func run(ctx context.Context, target, assetType, optJSON string, state checkstat
 		}
 	}
 
-	// TODO: If target is "malformed" perhaps we should not return error
-	// but only log and error and return.
 	slashSplit := strings.SplitAfterN(target, "/", 2)
 	if len(slashSplit) <= 1 {
-		return errors.New(target + " is not a valid target")
+		logger.Warnf("%s does not have a path", target)
 	}
-	// TODO: If target is "malformed" perhaps we should not return error
-	// but only log and error and return.
-	targetSplit := strings.Split(slashSplit[1], ":")
+	targetSplit := strings.Split(slashSplit[len(slashSplit)-1], ":")
 	if len(targetSplit) != 2 {
-		return errors.New(target + "is not a valid target")
+		logger.Warnf("%s does not have a tag", target)
 	}
 
 	registryDomain := strings.Trim(slashSplit[0], "/")

--- a/cmd/vulcan-trivy/vulcan-trivy.go
+++ b/cmd/vulcan-trivy/vulcan-trivy.go
@@ -252,7 +252,7 @@ func processVulns(results scanResponse, registryEnvDomain, target string, state 
 	for key, det := range outdatedPackageVulns {
 		l := det.packages
 
-		// Sort CVEs by severity
+		// Sort CVEs by severity desc, cve desc
 		sort.Slice(l, func(i, j int) bool {
 			if l[i].severity == l[j].severity {
 				return cve2num(l[i].cve) > cve2num(l[j].cve)
@@ -361,10 +361,10 @@ func getScore(severity string) float32 {
 	return report.SeverityThresholdNone
 }
 
-var CVERegex = regexp.MustCompile(`^CVE-(\d{4})-(\d+)$`)
+var cveRegex = regexp.MustCompile(`^CVE-(\d{4})-(\d+)$`)
 
 func cve2num(cve string) int {
-	m := CVERegex.FindStringSubmatch(cve)
+	m := cveRegex.FindStringSubmatch(cve)
 	if len(m) == 3 {
 		year, _ := strconv.Atoi(m[1])
 		id, _ := strconv.Atoi(m[2])

--- a/cmd/vulcan-trivy/vulcan-trivy.go
+++ b/cmd/vulcan-trivy/vulcan-trivy.go
@@ -283,9 +283,10 @@ func processVulns(results scanResponse, registryEnvDomain, target string, state 
 				row["CWEs"] = strings.Join(urls, ", ")
 			}
 			if p.link == "" {
-				p.link = fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", p.cve)
+				row["Vulnerabilities"] = p.cve
+			} else {
+				row["Vulnerabilities"] = fmt.Sprintf("[%s](%s)", p.cve, p.link)
 			}
-			row["Vulnerabilities"] = fmt.Sprintf("[%s](%s)", p.cve, p.link)
 			row["Severity"] = p.severity
 			vp.Rows = append(vp.Rows, row)
 		}

--- a/cmd/vulcan-trivy/vulcan-trivy.go
+++ b/cmd/vulcan-trivy/vulcan-trivy.go
@@ -33,7 +33,6 @@ const (
 var (
 	checkName        = "vulcan-trivy"
 	logger           = check.NewCheckLog(checkName)
-	trivyCachePath   = "trivy_cache"
 	reportOutputFile = "report.json"
 )
 
@@ -122,7 +121,6 @@ func run(ctx context.Context, target, assetType, optJSON string, state checkstat
 	// Build trivy command with arguments.
 	triviCmd := "./trivy"
 	triviArgs := []string{
-		"--cache-dir", trivyCachePath,
 		"image",
 		"-f", "json",
 		"-o", reportOutputFile,
@@ -306,7 +304,7 @@ func generateDetails(registry, target string) string {
 		"Run the following command to obtain the full report in your computer.",
 		"If using a public docker registry:",
 		fmt.Sprintf(`
-	docker run -it --rm aquasec/trivy %s`, target,
+	docker run -it --rm aquasec/trivy image %s`, target,
 		),
 		"\n",
 		"If using a private docker registry:",
@@ -315,7 +313,7 @@ func generateDetails(registry, target string) string {
 		-e TRIVY_AUTH_URL=https://%s \
 		-e TRIVY_USERNAME=$REGISTRY_USERNAME \
 		-e TRIVY_PASSWORD=$REGISTRY_PASSWORD \
-		aquasec/trivy %s`, registry, target,
+		aquasec/trivy image %s`, registry, target,
 		),
 	}
 	return strings.Join(details, "\n")


### PR DESCRIPTION
- Upgrade trivy base image to 0.24.4
- Adapt `--download-db-only` breaking change.
- Leverage `TRIVY_CACHE_DIR` env variable
- Add information about the context (os packages, lang-packages, ...)
- Clearly identify the path where the reference is (i.e. path to a go binary, path to a jar file). 
- Fill the resource table with the vulnerabilities.
 