### PR TITLE
semgrep owasp field comment

### DIFF
--- a/cmd/vulcan-semgrep/semgrep.go
+++ b/cmd/vulcan-semgrep/semgrep.go
@@ -59,7 +59,8 @@ type Result struct {
 	Extra struct {
 		Message  string `json:"message"`
 		Metadata struct {
-			Owasp         string   `json:"owasp"`
+			// The field Owasp can be a string or a []string
+			// Owasp         string   `json:"owasp"`
 			Cwe           string   `json:"cwe"`
 			SourceRuleURL string   `json:"source-rule-url"`
 			References    []string `json:"references"`


### PR DESCRIPTION
The field metadata.owasp can be a string or []string and this can be create a unmarshall error. I comment the field for solve this given that the field is not used.

Thanks!