### PR TITLE
bugfix: remove informational label from all checks

### DIFF
--- a/cmd/vulcan-burp/burp.go
+++ b/cmd/vulcan-burp/burp.go
@@ -237,7 +237,7 @@ func fillVulns(ievents []resturp.IssueEvent, defs []resturp.IssueDefinition) []r
 			Description:     issueDefinition.Description,
 			Recommendations: []string{issueDefinition.Remediation},
 			Score:           severityToScore(i.Issue.Severity),
-			Labels:          []string{"web", "burp"},
+			Labels:          []string{"issue", "web", "burp"},
 			Details:         i.Issue.Description,
 			Resources: []report.ResourcesGroup{
 				{
@@ -265,11 +265,6 @@ func fillVulns(ievents []resturp.IssueEvent, defs []resturp.IssueDefinition) []r
 					vuln.References = append(vuln.References, string(r[1]))
 				}
 			}
-		}
-		if vuln.Score == 0 {
-			vuln.Labels = append(vuln.Labels, "informational")
-		} else {
-			vuln.Labels = append(vuln.Labels, confidenceToLabel(i.Issue.Confidence))
 		}
 		vulnsMap[issueDefinition.Name] = vuln
 	}
@@ -307,12 +302,4 @@ func severityToScore(risk string) float32 {
 	default:
 		return report.SeverityThresholdNone
 	}
-}
-
-func confidenceToLabel(confidence string) string {
-	switch confidence {
-	case "certain":
-		return "issue"
-	}
-	return "potential"
 }

--- a/cmd/vulcan-dmarc/dmarc_vulnerabilities.go
+++ b/cmd/vulcan-dmarc/dmarc_vulnerabilities.go
@@ -215,7 +215,7 @@ var vulns = map[string]report.Vulnerability{
 		Recommendations: []string{
 			"Explicitly define the value of tag 'rua'",
 		},
-		Labels:      []string{"informational", "dns"},
+		Labels:      []string{"issue", "dns"},
 		Fingerprint: helpers.ComputeFingerprint(),
 	},
 	"tag-ruf-not-configured": report.Vulnerability{
@@ -238,7 +238,7 @@ var vulns = map[string]report.Vulnerability{
 		Recommendations: []string{
 			"Explicitly define the value of tag 'ruf'",
 		},
-		Labels:      []string{"informational", "dns"},
+		Labels:      []string{"issue", "dns"},
 		Fingerprint: helpers.ComputeFingerprint(),
 	},
 	"tag-pct-not-100": report.Vulnerability{
@@ -257,7 +257,7 @@ var vulns = map[string]report.Vulnerability{
 		Recommendations: []string{
 			"Set tag 'pct' to be '100'",
 		},
-		Labels:      []string{"informational", "dns"},
+		Labels:      []string{"issue", "dns"},
 		Fingerprint: helpers.ComputeFingerprint(),
 	},
 	"tag-rua-not-valid-mailto": report.Vulnerability{

--- a/cmd/vulcan-exposed-bgp/main.go
+++ b/cmd/vulcan-exposed-bgp/main.go
@@ -39,7 +39,7 @@ var (
 			"https://tools.ietf.org/html/bcp194#section-4",
 		},
 		AffectedResource: fmt.Sprintf("%d/tcp", defaultBGPPort),
-		Labels:           []string{"informational", "bgp", "discovery"},
+		Labels:           []string{"issue", "bgp", "discovery"},
 		Fingerprint:      helpers.ComputeFingerprint(),
 	}
 )

--- a/cmd/vulcan-exposed-hdfs/main.go
+++ b/cmd/vulcan-exposed-hdfs/main.go
@@ -61,7 +61,7 @@ var (
 		Description:     "The ports are commonly used by Hadoop Distributed File System, and exposing them may allow to execute jobs by external attackers.",
 		Score:           report.SeverityThresholdNone,
 		Recommendations: []string{"Block access to Hadoop related ports from the internet."},
-		Labels:          []string{"hdfs"},
+		Labels:          []string{"issue", "hdfs"},
 	}
 
 	logger *logrus.Entry
@@ -86,10 +86,7 @@ func processExposedHDFSVulns(target string, nmapReport *gonmap.NmapRun, r *regex
 			c := false
 			if confirmed(target, strconv.Itoa(port.PortId), port.Service.Product) {
 				vuln.Score = report.SeverityThresholdCritical
-				vuln.Labels = append(vuln.Labels, "issue")
 				c = true
-			} else {
-				vuln.Labels = append(vuln.Labels, "informational")
 			}
 
 			networkResource := map[string]string{

--- a/cmd/vulcan-exposed-http-resources/main.go
+++ b/cmd/vulcan-exposed-http-resources/main.go
@@ -72,7 +72,7 @@ var (
 	falseOKVuln = report.Vulnerability{
 		Summary:         "Incorrect Successful HTTP Response",
 		Description:     "The HTTP server is responding \"200 OK\" to requests for unexistent resources.",
-		Labels:          []string{"informational", "http"},
+		Labels:          []string{"issue", "http"},
 		ImpactDetails:   "Unreliable response statuses prevent the check from identifying accidentally exposed resources.",
 		Score:           report.SeverityThresholdNone,
 		Recommendations: []string{"Ensure that the server only returns \"200 OK\" when a request is successful."},

--- a/cmd/vulcan-exposed-http/main.go
+++ b/cmd/vulcan-exposed-http/main.go
@@ -90,7 +90,7 @@ func exposedHTTP(target string, nmapReport *gonmap.NmapRun, state checkstate.Sta
 			}
 			v := report.Vulnerability{
 				AffectedResource: fmt.Sprintf("%d/%s", port.PortId, port.Protocol),
-				Labels:           []string{port.Protocol, "issue"},
+				Labels:           []string{"issue", "discovery"},
 				Fingerprint:      helpers.ComputeFingerprint(port.Service.Product, port.Service.Version),
 				Summary:          "Exposed HTTP Port",
 				Description:      "An HTTP server is listening at least in one port ot the server.",

--- a/cmd/vulcan-exposed-router-ports/main.go
+++ b/cmd/vulcan-exposed-router-ports/main.go
@@ -71,7 +71,7 @@ func exposedRouterPorts(target string, nmapReport *gonmap.NmapRun, state checkst
 			vuln := exposedVuln
 			vuln.AffectedResource = fmt.Sprintf("%d/%s", port.PortId, port.Protocol)
 			vuln.Fingerprint = helpers.ComputeFingerprint(port.Service.Product)
-			vuln.Labels = []string{"informational", "discovery"}
+			vuln.Labels = []string{"issue", "discovery"}
 			vuln.Resources = []report.ResourcesGroup{{
 				Name: "Network Resources",
 				Header: []string{

--- a/cmd/vulcan-exposed-varnish/main.go
+++ b/cmd/vulcan-exposed-varnish/main.go
@@ -28,14 +28,14 @@ var (
 		Summary:     "Web Cache Exposed",
 		Description: "The asset appears to be a Web Cache, as the X-Cache HTTP header is present in the HTTP response.",
 		Score:       report.SeverityThresholdNone,
-		Labels:      []string{"informational", "discovery"},
+		Labels:      []string{"issue", "discovery"},
 	}
 
 	exposedVarnish = report.Vulnerability{
 		Summary:     "Varnish Cache Exposed",
 		Description: "The asset appears to be a Varnish Cache, as the X-Cache header is present and the varnish literal has been found in the response.",
 		Score:       report.SeverityThresholdNone,
-		Labels:      []string{"informational", "discovery"},
+		Labels:      []string{"issue", "discovery"},
 	}
 )
 

--- a/cmd/vulcan-http-headers/main.go
+++ b/cmd/vulcan-http-headers/main.go
@@ -39,7 +39,7 @@ var behindOktaVuln = report.Vulnerability{
 	Summary:     "Okta Authentication",
 	Description: "The asset is not reachable because it is behind Okta.",
 	Score:       report.SeverityThresholdNone,
-	Labels:      []string{"informational", "http"},
+	Labels:      []string{"issue", "http"},
 }
 
 func main() {

--- a/cmd/vulcan-http-headers/vulnerabilities.go
+++ b/cmd/vulcan-http-headers/vulnerabilities.go
@@ -140,11 +140,11 @@ func processCookies(vuln report.Vulnerability, target string, r observatoryResul
 	case `cookies-without-secure-flag-but-protected-by-hsts`:
 		vuln.Details = "Cookies set without using the 'Secure' flag, but transmission over HTTP prevented by HSTS."
 		vuln.Score = report.SeverityThresholdNone
-		vuln.Labels = []string{"informational", "http"}
+		vuln.Labels = []string{"issue", "http"}
 	case `cookies-session-without-secure-flag-but-protected-by-hsts`:
 		vuln.Details = "Session cookie set without the 'Secure' flag, but transmission over HTTP prevented by HSTS."
 		vuln.Score = report.SeverityThresholdNone
-		vuln.Labels = []string{"informational", "http"}
+		vuln.Labels = []string{"issue", "http"}
 	case `cookies-without-secure-flag`:
 		vuln.Details = "Cookies set without using the 'Secure' flag or set over HTTP."
 		vuln.Score = 2.0 // Low.
@@ -343,7 +343,7 @@ func processHSTS(vuln report.Vulnerability, target string, r observatoryResult, 
 			"max-age must be set to a minimum of six months (15768000), but longer periods such as two years (63072000) are recommended. "+
 				"Note that once this value is set, the site must continue to support HTTPS until the expiry time has been reached.",
 		)
-		vuln.Labels = []string{"informational", "http"}
+		vuln.Labels = []string{"issue", "http"}
 	case `hsts-not-implemented`:
 		vuln.Summary = "HTTP Strict Transport Security Not Implemented"
 		vuln.Recommendations = append(vuln.Recommendations, "Implement HSTS in the site.")
@@ -555,7 +555,7 @@ var observatoryGrading = report.Vulnerability{
 	Description: "The Mozilla HTTP Observatory is a set of tools to analyze your website and inform you if you are utilizing the many available methods to secure it. " +
 		"Some of the HTTP check results shown in this report come from using this tool. As the tool is giving a global score, we are showing it to you too. ",
 	Score:  report.SeverityThresholdNone,
-	Labels: []string{"informational", "http"},
+	Labels: []string{"issue", "http"},
 	Recommendations: []string{
 		"Fix all the vulnerabilities reported for the HTTP headers of your website to improve the score.",
 	},

--- a/cmd/vulcan-ipv6/main.go
+++ b/cmd/vulcan-ipv6/main.go
@@ -34,7 +34,7 @@ var (
 		References: []string{
 			"https://www.ietf.org/rfc/rfc2460.txt",
 		},
-		Labels:      []string{"informational", "discovery"},
+		Labels:      []string{"issue", "discovery"},
 		Fingerprint: helpers.ComputeFingerprint(),
 	}
 )

--- a/cmd/vulcan-masscan/main.go
+++ b/cmd/vulcan-masscan/main.go
@@ -38,7 +38,7 @@ var (
 		References: []string{
 			"https://tools.ietf.org/html/rfc4778",
 		},
-		Labels:      []string{"informational", "discovery"},
+		Labels:      []string{"issue", "discovery"},
 		Fingerprint: helpers.ComputeFingerprint(),
 	}
 )

--- a/cmd/vulcan-mx/main.go
+++ b/cmd/vulcan-mx/main.go
@@ -27,7 +27,7 @@ var (
 		Recommendations: []string{
 			"It is recommended to run DMARC, DKIM and SPF checks for each domain that contain MX records.",
 		},
-		Labels:      []string{"informational", "discovery"},
+		Labels:      []string{"issue", "discovery"},
 		Fingerprint: helpers.ComputeFingerprint(),
 	}
 )

--- a/cmd/vulcan-nessus/nessus.go
+++ b/cmd/vulcan-nessus/nessus.go
@@ -341,7 +341,7 @@ func (r *runner) translateFromNessusToVulcan(hostID int64, target string, nessus
 
 	vulcanVulnerability := report.Vulnerability{
 		Summary: p.Name,
-		Labels:  []string{"nessus"},
+		Labels:  []string{"issue", "nessus"},
 	}
 
 	// There might be more than one attribute with the same name. For example
@@ -411,11 +411,6 @@ func (r *runner) translateFromNessusToVulcan(hostID int64, target string, nessus
 		// As there are no ports specified in the Output, we can't be more
 		// specific for the affected resource than the whole target.
 		vulcanVulnerability.AffectedResource = target
-		if vulcanVulnerability.Score == 0 {
-			vulcanVulnerability.Labels = append(vulcanVulnerability.Labels, "informational")
-		} else {
-			vulcanVulnerability.Labels = append(vulcanVulnerability.Labels, "issue")
-		}
 		// As we don't have context information from the Output, at least we
 		// use the score as a fingerprint.
 		vulcanVulnerability.Fingerprint = helpers.ComputeFingerprint(vulcanVulnerability.Score)
@@ -440,11 +435,6 @@ func (r *runner) translateFromNessusToVulcan(hostID int64, target string, nessus
 			// Again, if there are no ports specified we can't be more precise
 			// than using the target as the affected resource.
 			v.AffectedResource = target
-			if v.Score == 0 {
-				v.Labels = append(v.Labels, "informational")
-			} else {
-				v.Labels = append(v.Labels, "issue")
-			}
 			// Apart from the score, we can use the Details as a fingerprint,
 			// that is supposed to give the context of the vulnerability in the
 			// scanned target.
@@ -485,11 +475,6 @@ func (r *runner) translateFromNessusToVulcan(hostID int64, target string, nessus
 			}
 
 			v.AffectedResource = portInformation
-			if v.Score == 0 {
-				v.Labels = append(v.Labels, "informational")
-			} else {
-				v.Labels = append(v.Labels, "issue")
-			}
 			v.Fingerprint = helpers.ComputeFingerprint(v.Score, v.Details, v.Resources)
 
 			vulnerabilities = append(vulnerabilities, v)

--- a/cmd/vulcan-nuclei/main.go
+++ b/cmd/vulcan-nuclei/main.go
@@ -182,7 +182,7 @@ func processNucleiFindings(target string, nucleiFindings []ResultEvent) []*repor
 			Score:            getScore(v.Info.Severity),
 			References:       v.Info.Reference,
 			Recommendations:  recommendations,
-			Labels:           []string{"nuclei", "issue", v.Type},
+			Labels:           []string{"nuclei", "issue"},
 		}
 
 		findingResources := report.ResourcesGroup{

--- a/cmd/vulcan-prowler/main.go
+++ b/cmd/vulcan-prowler/main.go
@@ -159,7 +159,7 @@ var (
 			     Information gathered by executing the CIS benchmark on the account.
 		</p>
 			`,
-		Labels: []string{"informational", "compliance", "cis", "aws"},
+		Labels: []string{"compliance", "cis", "aws"},
 		References: []string{
 			"https://d0.awsstatic.com/whitepapers/compliance/AWS_CIS_Foundations_Benchmark.pdf",
 			"https://github.com/toniblyx/prowler",

--- a/cmd/vulcan-spf/spf_vulnerabilities.go
+++ b/cmd/vulcan-spf/spf_vulnerabilities.go
@@ -75,7 +75,7 @@ var vulns = map[string]report.Vulnerability{
 		Recommendations: []string{
 			"Explictly define an 'all' or a 'redirect'",
 		},
-		Labels:      []string{"informational", "dns"},
+		Labels:      []string{"issue", "dns"},
 		Fingerprint: helpers.ComputeFingerprint(),
 	},
 	"all-configured-as-PASS": report.Vulnerability{
@@ -158,7 +158,7 @@ var vulns = map[string]report.Vulnerability{
 		Recommendations: []string{
 			"Review the SPF policy and reduce the number of DNS queries invoked to be equal or less than 10",
 		},
-		Labels:      []string{"informational", "dns"},
+		Labels:      []string{"issue", "dns"},
 		Fingerprint: helpers.ComputeFingerprint(),
 	},
 	"multiple-spf-found": report.Vulnerability{

--- a/cmd/vulcan-unclassified/main.go
+++ b/cmd/vulcan-unclassified/main.go
@@ -19,7 +19,7 @@ var (
 		Summary:     "Unclassified Vulnerability",
 		Description: "Example vulnerability to test the monitoring of unclassified vulnerabilities.",
 		Score:       report.SeverityThresholdNone,
-		Labels:      []string{"informational"},
+		Labels:      []string{"issue"},
 	}
 )
 

--- a/cmd/vulcan-wpscan/main.go
+++ b/cmd/vulcan-wpscan/main.go
@@ -146,7 +146,7 @@ func addVersionInfoVuln(state checkstate.State, r *WpScanReport) {
 			Details:          details,
 			Score:            report.SeverityThresholdNone,
 			AffectedResource: r.EffectiveURL,
-			Labels:           []string{"informational", "wordpress", "http"},
+			Labels:           []string{"issue", "wordpress", "http"},
 		}
 
 		if len(r.InterestingFindings) > 0 {

--- a/cmd/vulcan-zap/zap.go
+++ b/cmd/vulcan-zap/zap.go
@@ -68,12 +68,7 @@ func processAlert(a map[string]interface{}) (report.Vulnerability, error) {
 	}
 	v.Score = riskToScore(risk)
 
-	v.Labels = []string{"web", "zap"}
-	if strings.ToLower(risk) == "informational" {
-		v.Labels = append(v.Labels, "informational")
-	} else {
-		v.Labels = append(v.Labels, "issue")
-	}
+	v.Labels = []string{"issue", "web", "zap"}
 
 	cweID, ok := a["cweid"].(string)
 	if !ok {


### PR DESCRIPTION
The fact that the same vulnerability might have different labels per execution was introducing some unexpected behaviours, as the labels are defined at _issue_ level in the Vulnerability DB model. This was particularly triggered in those cases where the same issue might have a score 0 or different from 0 depending on the execution.

It was discussed an agreed to not label vulnerabilities as `informational` when the score is 0. We will label them with the exact same labels than when the score is different from 0. Even more, labels shouldn't change during runtime, as they shouldn't include runtime information. 