### PR TITLE
Support configure ignored scanners for fingerprint generation

### DIFF
--- a/cmd/vulcan-zap/manifest.toml
+++ b/cmd/vulcan-zap/manifest.toml
@@ -5,12 +5,15 @@ Timeout = 36000 # 10 hours. Expressed in seconds as an integer.
 # 10062 - PII Disclosure - Too many false positive results.
 # 10003 - Vulnerable JS Library - Duplicates the Retire.js check.
 # 10108 - Reverse Tabnabbing - Not relevant for modern browser versions.
+# Ignored scanners for fingerprint:
+# 40018 - SQL Injection - Too many false positive results with variable resources.
 # Source: https://www.zaproxy.org/docs/alerts/
 Options = """{
     "depth": 2, 
     "active": true, 
     "min_score": 0, 
     "disabled_scanners": ["10062", "10003", "10108"],
+    "ignored_fingerprint_scanners": ["40018"],
     "max_spider_duration": 0,
     "max_scan_duration": 0, 
     "max_rule_duration": 0,

--- a/cmd/vulcan-zap/zap.go
+++ b/cmd/vulcan-zap/zap.go
@@ -134,3 +134,11 @@ func processAlert(a map[string]interface{}) (report.Vulnerability, error) {
 
 	return v, nil
 }
+
+func parsePluginID(a map[string]interface{}) (string, error) {
+	pluginID, ok := a["pluginId"].(string)
+	if !ok {
+		return "", errors.New("error parsing alert plugin ID")
+	}
+	return pluginID, nil
+}


### PR DESCRIPTION
This PR adds a new supported option for `vulcan-zap` check which allows to define a list of Zap proxy plugin IDs for which the resources associated with the vulnerabilities reported by them will not be taken into account for the fingerprint generation.

The reason for this functionality is to try to mitigate the variability of the fingerprint for some type of vulnerabilities, especially the injection type ones like SQLi, which eventually does not allow Vulcan end users to mark a finding as _false positive_ permanently, as the finding is recurrently being reopened due to the variations on the associated resources, for example the payload used for the attack.