### PR TITLE
Force status 200 for Laravel

### DIFF
--- a/cmd/vulcan-exposed-http-resources/resources.yaml
+++ b/cmd/vulcan-exposed-http-resources/resources.yaml
@@ -380,6 +380,7 @@
   - ".env_hosted"
   - ".env_baremetal"
   regex: "(APP_ENV|DB_DATABASE|DB_USERNAME|DB_PASSWORD)"
+  status: 200
   severity: 8.9
   description: Exposed Laravel environment file.
 


### PR DESCRIPTION
When Laravel is in debug mode it generates a 404 page showing the source code of the exception

```php
$kernel = new AppKernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
$request = Request::createFromGlobals();
$response = $kernel->handle($request);$response->send();
```

Another option could be to remove APP_ENV from the regex
