### PR TITLE
Fix GitLeaks label not supported by artifactory

### DIFF
--- a/cmd/vulcan-gitleaks/Dockerfile
+++ b/cmd/vulcan-gitleaks/Dockerfile
@@ -2,6 +2,9 @@
 
 FROM zricethezav/gitleaks
 
+# Override base label with 🔑 not supported by artifactory.
+LABEL org.opencontainers.image.description="Protect and discover secrets using Gitleaks"
+
 # Override entrypoint
 ENTRYPOINT ["/usr/bin/env"]
 


### PR DESCRIPTION
The base image contains labels not compatible with jfrog artifactory (it complains with `manifest invalid: manifest invalid`)

```sh
docker inspect zricethezav/gitleaks | jq '.[].Config.Labels'
{
  "org.opencontainers.image.created": "2022-06-20T20:12:37.413Z",
  "org.opencontainers.image.description": "Protect and discover secrets using Gitleaks 🔑",
  "org.opencontainers.image.licenses": "MIT",
  "org.opencontainers.image.revision": "70028079b4c47e0dd2e1ed116aeaeeac23ef0c1d",
  "org.opencontainers.image.source": "https://github.com/zricethezav/gitleaks",
  "org.opencontainers.image.title": "gitleaks",
  "org.opencontainers.image.url": "https://github.com/zricethezav/gitleaks",
  "org.opencontainers.image.version": "v8.8.8"
}
```
This PR replaces that label.

NOTE: An improvement out of the scope of this fix would be to generate those labels for all the vulcan-checks.