### PR TITLE
Trivy add git

### DIFF
--- a/cmd/vulcan-trivy/Dockerfile
+++ b/cmd/vulcan-trivy/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright 2020 Adevinta
 
-FROM aquasec/trivy:0.32.1 as dependency_builder
+FROM aquasec/trivy:0.33.0 as dependency_builder
 
 ENV TRIVY_CACHE_DIR=/trivy_cache
 

--- a/cmd/vulcan-trivy/local.toml.example
+++ b/cmd/vulcan-trivy/local.toml.example
@@ -6,4 +6,20 @@ AssetType = "DockerImage"
 # registry-1.docker.io/library/postgres:9.6
 
 # example Options
-# Options = '{"force_update_db": false, "ignore_unfixed": false, "severities":"UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"}'
+# Options = """{
+#     "force_update_db": false, 
+#     "ignore_unfixed": false, 
+#     "severities":"UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL",
+#     "depth": 1,
+#     "branch":"",
+#     "git_checks": {
+#         "vuln": true,
+#         "secret": false,
+#         "config": false
+#     },
+#     "image_checks": {
+#         "vuln": true,
+#         "secret": false,
+#         "config": false
+#     }
+# }"""

--- a/cmd/vulcan-trivy/manifest.toml
+++ b/cmd/vulcan-trivy/manifest.toml
@@ -1,4 +1,17 @@
 Description = "Scan docker images and Git repositories using aquasec/trivy"
 AssetTypes = ["DockerImage", "GitRepository"]
 RequiredVars = ["REGISTRY_DOMAIN", "REGISTRY_USERNAME", "REGISTRY_PASSWORD", "GITHUB_ENTERPRISE_ENDPOINT", "GITHUB_ENTERPRISE_TOKEN"]
-Options = '{"depth": 1, "branch":"", "image_enabled": true, "fs_enabled": true, "configs_enabled": true, "secrets_enabled": true}'
+Options = """{
+    "depth": 1,
+    "branch":"",
+    "git_checks": {
+        "vuln": true,
+        "secret": false,
+        "config": false
+    },
+    "image_checks": {
+        "vuln": true,
+        "secret": false,
+        "config": false
+    }
+}"""

--- a/cmd/vulcan-trivy/manifest.toml
+++ b/cmd/vulcan-trivy/manifest.toml
@@ -1,6 +1,11 @@
 Description = "Scan docker images and Git repositories using aquasec/trivy"
-AssetTypes = ["DockerImage", "GitRepository"]
-RequiredVars = ["REGISTRY_DOMAIN", "REGISTRY_USERNAME", "REGISTRY_PASSWORD", "GITHUB_ENTERPRISE_ENDPOINT", "GITHUB_ENTERPRISE_TOKEN"]
+AssetTypes = ["DockerImage", 
+    # "GitRepository"
+]
+RequiredVars = [
+    "REGISTRY_DOMAIN", "REGISTRY_USERNAME", "REGISTRY_PASSWORD", 
+    # "GITHUB_ENTERPRISE_ENDPOINT", "GITHUB_ENTERPRISE_TOKEN"
+]
 Options = """{
     "depth": 1,
     "branch":"",

--- a/cmd/vulcan-trivy/manifest.toml
+++ b/cmd/vulcan-trivy/manifest.toml
@@ -1,3 +1,4 @@
-Description = "Scan docker images using aquasec/trivy"
-AssetTypes = ["DockerImage"]
-RequiredVars = ["REGISTRY_DOMAIN", "REGISTRY_USERNAME", "REGISTRY_PASSWORD"]
+Description = "Scan docker images and Git repositories using aquasec/trivy"
+AssetTypes = ["DockerImage", "GitRepository"]
+RequiredVars = ["REGISTRY_DOMAIN", "REGISTRY_USERNAME", "REGISTRY_PASSWORD", "GITHUB_ENTERPRISE_ENDPOINT", "GITHUB_ENTERPRISE_TOKEN"]
+Options = '{"depth": 1, "branch":""}'

--- a/cmd/vulcan-trivy/manifest.toml
+++ b/cmd/vulcan-trivy/manifest.toml
@@ -1,4 +1,4 @@
 Description = "Scan docker images and Git repositories using aquasec/trivy"
 AssetTypes = ["DockerImage", "GitRepository"]
 RequiredVars = ["REGISTRY_DOMAIN", "REGISTRY_USERNAME", "REGISTRY_PASSWORD", "GITHUB_ENTERPRISE_ENDPOINT", "GITHUB_ENTERPRISE_TOKEN"]
-Options = '{"depth": 1, "branch":"", "image_enabled": true, "fs_enabled": true, "configs_enabled": false, "secrets_enabled": false }'
+Options = '{"depth": 1, "branch":"", "image_enabled": true, "fs_enabled": true, "configs_enabled": true, "secrets_enabled": true}'

--- a/cmd/vulcan-trivy/manifest.toml
+++ b/cmd/vulcan-trivy/manifest.toml
@@ -1,4 +1,4 @@
 Description = "Scan docker images and Git repositories using aquasec/trivy"
 AssetTypes = ["DockerImage", "GitRepository"]
 RequiredVars = ["REGISTRY_DOMAIN", "REGISTRY_USERNAME", "REGISTRY_PASSWORD", "GITHUB_ENTERPRISE_ENDPOINT", "GITHUB_ENTERPRISE_TOKEN"]
-Options = '{"depth": 1, "branch":""}'
+Options = '{"depth": 1, "branch":"", "image_enabled": true, "fs_enabled": true, "configs_enabled": false, "secrets_enabled": false }'

--- a/cmd/vulcan-trivy/vulcan-trivy.go
+++ b/cmd/vulcan-trivy/vulcan-trivy.go
@@ -104,6 +104,7 @@ type outdatedPackage struct {
 	cve      string
 	link     string
 	cwes     []string
+	title    string
 }
 
 func main() {
@@ -329,6 +330,7 @@ func processVulns(results scanResponse, details string, state checkstate.State) 
 				cve:      tv.VulnerabilityID,
 				link:     tv.PrimaryURL,
 				cwes:     tv.CweIDs,
+				title:    tv.Title,
 			}
 
 			if det, ok := outdatedPackageVulns[key]; ok {
@@ -352,6 +354,7 @@ func processVulns(results scanResponse, details string, state checkstate.State) 
 			"Vulnerabilities",
 			"Severity",
 			"CWEs",
+			"Title",
 		},
 	}
 
@@ -396,6 +399,7 @@ func processVulns(results scanResponse, details string, state checkstate.State) 
 				row["Vulnerabilities"] = fmt.Sprintf("[%s](%s)", p.cve, p.link)
 			}
 			row["Severity"] = p.severity
+			row["Title"] = p.title
 			vp.Rows = append(vp.Rows, row)
 		}
 

--- a/cmd/vulcan-trivy/vulcan-trivy.go
+++ b/cmd/vulcan-trivy/vulcan-trivy.go
@@ -40,6 +40,12 @@ var (
 	logger           = check.NewCheckLog(checkName)
 	reportOutputFile = "report.json"
 	localTargets     = regexp.MustCompile(`https?://(localhost|host\.docker\.internal|172\.17\.0\.1)`)
+
+	FilePatters = []string{
+		// trivy only detect requirements.txt files
+		`pip:/requirements/[^/]+\.txt`,    // All the .txt files in a requirements directory.
+		`pip:[^/]*requirements[^/]*\.txt`, // All the files .txt that contains requirements
+	}
 )
 
 type options struct {
@@ -166,6 +172,10 @@ func run(ctx context.Context, target, assetType, optJSON string, state checkstat
 		trivyArgs = append(trivyArgs, []string{"--security-checks", "vuln,secret"}...)
 	} else {
 		trivyArgs = append(trivyArgs, []string{"--security-checks", "vuln"}...)
+	}
+
+	for _, p := range FilePatters {
+		trivyArgs = append(trivyArgs, []string{"--file-patterns", fmt.Sprintf(`"%s"`, p)}...)
 	}
 
 	if strings.Contains(assetType, "DockerImage") {

--- a/cmd/vulcan-trivy/vulcan-trivy.go
+++ b/cmd/vulcan-trivy/vulcan-trivy.go
@@ -326,7 +326,7 @@ func processMisconfigs(results scanResponse, target string, branch string, state
 					Recommendations:  []string{tv.Resolution},
 					References:       tv.References,
 					Score:            getScore(tv.Severity),
-					AffectedResource: computeAffectedResource(target, branch, tt.Target, 1),
+					AffectedResource: tt.Target,
 					Resources: []report.ResourcesGroup{{
 						Name: "Found in",
 					},


### PR DESCRIPTION
### Vuln scanning for GitRepository.
- Add GitRepository as an asset type.
- Bumps aquasec/trivy to `0.32.1`
- Added Title to the resource table with a short vulnerability description for both docker/git.
- No secret scanning activated (`--security-checks vuln`) already done with GitLeaks check.

### config scanning
- Activated for  GitRepository (not in DockerImage as it's very unusual to find config files inside a Dockerimage).
- Reference `.trivyignore` in details on how to ignore trivy findings.
- Uses the severity provided by trivy.
