### PR TITLE
vulcan-prowler: Fix region option handling

### DIFF
--- a/cmd/vulcan-prowler/main.go
+++ b/cmd/vulcan-prowler/main.go
@@ -29,7 +29,9 @@ import (
 )
 
 const (
-	defaultRegion          = `eu-west-1`
+	// defaultAPIRegion defines the default AWS region to use when querying AWS
+	// services API endpoints.
+	defaultAPIRegion       = `eu-west-1`
 	defaultSessionDuration = 3600 // 1 hour.
 
 	envEndpoint = `VULCAN_ASSUME_ROLE_ENDPOINT`
@@ -191,9 +193,6 @@ func buildOptions(optJSON string) (options, error) {
 		if err := json.Unmarshal([]byte(optJSON), &opts); err != nil {
 			return opts, err
 		}
-	}
-	if opts.Region == "" {
-		opts.Region = defaultRegion
 	}
 	if opts.Groups == nil {
 		opts.Groups = defaultGroups

--- a/cmd/vulcan-prowler/prowler.go
+++ b/cmd/vulcan-prowler/prowler.go
@@ -49,12 +49,17 @@ type entry struct {
 */
 
 func buildParams(region string, groups []string) []string {
-	return []string{
-		"-r", region,
+	params := []string{
 		"-g", strings.Join(groups, ","),
 		"-M", reportFormat,
 		"-F", reportName,
 	}
+	if region != "" {
+		params = append(params, "-r", region, "-f", region)
+	} else {
+		params = append(params, "-r", defaultAPIRegion)
+	}
+	return params
 }
 
 func runProwler(ctx context.Context, region string, groups []string) (*prowlerReport, error) {


### PR DESCRIPTION
This PR modifies vulcan-prowler implementation in order to fix the `region` option handling.
Previously the `region` option parameter available to configure the check, was set as value for the Prowler `-r` parameter. If we take a look at the Prowler documentation we can see:

```
Prowler has two parameters related to regions: -r that is used query AWS services API endpoints (it uses us-east-1 by default and required for GovCloud or China) and the option -f that is to filter those regions you only want to scan. For example if you want to scan Dublin only use -f eu-west-1 and if you want to scan Dublin and Ohio -f eu-west-1,us-east-1, note the regions are separated by a comma deliminator (it can be used as before with -f 'eu-west-1,us-east-1').
```
Therefore, our previous usage of the `-r` parameter was not inline with our actual intention, which is to limit the Prowler scan to an specific region. This PR tries to address that mistake by using the region check option, in case it's specified, as the  `-r` and `-f` options fro Prowler. This is done in the following way:

- If region is specified, the value is set for the `-r` and `-f` Prowler parameters.
- If region is NOT specified, the default value `eu-west-1` is set for the `-r` parameter, and no value is set for the `-f` parameter, which means all regions will be scanned.

Other options are possible, such as allowing end users to set both, the "scan region" and "API region" parameters, and feedback is welcome in that regard. The defined option was chosen to maintain the current `region` naming parameter (in order to not break current spec) and not have an "heterogeneous" parameters definition where we have one "region" parameter and one "api_region" parameter for example.