### PR TITLE
Remove X-XSS-Protection findings

### DIFF
--- a/cmd/vulcan-http-headers/main.go
+++ b/cmd/vulcan-http-headers/main.go
@@ -168,8 +168,6 @@ func processResults(target string, r observatoryResult, s state.State) error {
 
 	processXFrame(xFrameVuln, target, r, s)
 
-	processXXSS(xXSSVuln, target, r, s)
-
 	processGrading(observatoryGrading, target, r, s)
 
 	return nil


### PR DESCRIPTION
As X-XSS-Protection header is deprecated and no longer recommended, I think it should be removed from this check. This change only make it ignore X-XSS-Protection findings, and does not change [the struct](https://github.com/adevinta/vulcan-checks/blob/master/cmd/vulcan-http-headers/observatory.go#L126-L133) `observatoryResult`.