### PR TITLE
Detect exposed Apache Airflow admin panels

### DIFF
--- a/cmd/vulcan-exposed-http-resources/resources.yaml
+++ b/cmd/vulcan-exposed-http-resources/resources.yaml
@@ -425,4 +425,19 @@
   status: 200
   regex: "This domain is for use in illustrative examples in documents"
   severity: 9.0
-  description: Unauthenticated SSRF in Hystrix dashboard 
+  description: Unauthenticated SSRF in Hystrix dashboard
+
+- paths:
+  - "login/"
+  - "admin/airflow/login"
+  status: 200
+  regex: "(Airflow - Login|Sign In - Airflow)"
+  severity: 6.9
+  description: Apache Airflow Admin Login Panel
+
+- paths:
+  - "admin/"
+  status: 200
+  regex: "<title>Airflow - DAGs</title>"
+  severity: 10
+  description: Apache Airflow Unauthenticated Access


### PR DESCRIPTION
A new medium vulnerability has been added for exposed authenticated Apache Airflow administration panels and a critical severity one has been added for panels that require no authentication and potentially allow data queries and code execution.