### PR TITLE
Exposed heap dump file and relevant improvements

### DIFF
--- a/cmd/vulcan-exposed-files/main.go
+++ b/cmd/vulcan-exposed-files/main.go
@@ -25,7 +25,7 @@ import (
 var (
 	checkName          = "vulcan-exposed-files"
 	logger             = check.NewCheckLog(checkName)
-	maxReadBytes int64 = 2097152 // 2MB. Maximum size to read from HTTP response.
+	maxReadBytes int64 = 2 * 1024 * 1024 // 2MB. Maximum size to read from HTTP response.
 )
 
 type FileCheck struct {

--- a/cmd/vulcan-exposed-files/main.go
+++ b/cmd/vulcan-exposed-files/main.go
@@ -25,7 +25,7 @@ import (
 var (
 	checkName          = "vulcan-exposed-files"
 	logger             = check.NewCheckLog(checkName)
-	maxReadBytes int64 = 2048 // Maximum size to read from HTTP response.
+	maxReadBytes int64 = 2097152 // 2MB. Maximum size to read from HTTP response.
 )
 
 type FileCheck struct {

--- a/cmd/vulcan-exposed-files/main.go
+++ b/cmd/vulcan-exposed-files/main.go
@@ -126,7 +126,7 @@ func scanTarget(ctx context.Context, target string, logger *logrus.Entry, state 
 		},
 		{
 			"Spring Boot environment variables",
-			report.SeverityThresholdMedium,
+			report.SeverityThresholdHigh,
 			[]string{"/env", "/actuator/env"},
 			[]string{"systemProperties", "systemEnvironment"},
 		},


### PR DESCRIPTION
Detect exposed heap dump issue in improperly configured Spring Boot.
Modifies the check to limit reading the response to a certain number of bytes to avoid downloading very large files in full.
Improve description and recommendations to be relevant to most possible findings.
Raise severity of exposed environment variables to high.