### PR TITLE
Solve problem with Cwe in semgrep check

### DIFF
--- a/cmd/vulcan-semgrep/semgrep.go
+++ b/cmd/vulcan-semgrep/semgrep.go
@@ -59,9 +59,9 @@ type Result struct {
 	Extra struct {
 		Message  string `json:"message"`
 		Metadata struct {
-			// The field Owasp can be a string or a []string
+			// The fields Owasp and Cwe can be a string or a []string
 			// Owasp         string   `json:"owasp"`
-			Cwe           string   `json:"cwe"`
+			// Cwe           string   `json:"cwe"`
 			SourceRuleURL string   `json:"source-rule-url"`
 			References    []string `json:"references"`
 		} `json:"metadata"`


### PR DESCRIPTION
Comment Cwe field for the problem that can be and array of strings or string, and this cause that the Check Fail i some cases.