### PR TITLE
Generate check tags to improve cache hit

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -35,7 +35,7 @@ CACHE_TAGS=(edge)
 if [[ $BRANCH == "master" ]]; then
     IMAGE_TAGS+=(latest edge)
     FORCE_BUILD="${FORCE_BUILD:-true}"
-    ADD_TAG_CHECK=false
+    ADD_TAG_CHECK=true
 elif [[ $TRAVIS_TAG != "" ]]; then
     IMAGE_TAGS+=("$TRAVIS_TAG")
     FORCE_BUILD="${FORCE_BUILD:-true}"


### PR DESCRIPTION
By pushing the check tags when building master greatly increases the chances when a new branch is created no docker image needs to be build unless a change has been made.
