### PR TITLE
Unsupported arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ go:
   - 1.18.x
 env:
   global:
-  - PLATFORMS="linux/arm64 linux/amd64"
+  - PLATFORMS="linux/amd64 linux/arm64"
+  - ARM64_EXCLUDE="(prowler|semgrep|zap)"   # Regex with the check names to exclude from arm64 build
 go_import_path: github.com/adevinta/vulcan-checks
 deploy:
   - provider: script

--- a/release-check-catalog.sh
+++ b/release-check-catalog.sh
@@ -2,6 +2,8 @@
 
 # Copyright 2022 Adevinta
 
+set -e
+
 mkdir pages/checktypes
 
 go install "github.com/adevinta/vulcan-check-catalog/cmd/vulcan-check-catalog@${VCC_VERSION:-main}"

--- a/release.sh
+++ b/release.sh
@@ -88,8 +88,15 @@ BUILDX_ARGS+=("--label" "org.opencontainers.image.ref=https://github.com/adevint
 # Iterate over all checks
 for check in "${CHECKS[@]}"; do
 
+    CHECK_PLATFORMS=$PLATFORMS
+    if [[ $check =~ $ARM64_EXCLUDE ]]; then
+        CHECK_PLATFORMS=${PLATFORMS// linux\/arm64/}
+    else
+        CHECK_PLATFORMS=$PLATFORMS
+    fi
+
     # Build the go app
-    for PLATFORM in $PLATFORMS; do
+    for PLATFORM in $CHECK_PLATFORMS; do
         OS=$(echo "$PLATFORM" | cut -f1 -d/)
         ARCH=$(echo "$PLATFORM" | cut -f2 -d/)
         CGO_ENABLED=0 GOOS=$OS GOARCH=$ARCH go build -ldflags="-s -w" -o "cmd/$check/$OS/$ARCH/$check" "$PWD/cmd/$check"
@@ -112,7 +119,7 @@ for check in "${CHECKS[@]}"; do
         --cache-to "type=inline" \
         --label "org.opencontainers.image.title=$check" \
         --label "org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
-        --platform="${PLATFORMS// /,}" \
+        --platform="${CHECK_PLATFORMS// /,}" \
         "cmd/$check" --push
 
     log_msg "Builded image $check:[${IMAGE_TAGS[*]}]"

--- a/release.sh
+++ b/release.sh
@@ -4,6 +4,8 @@
 
 # shellcheck disable=SC1091
 
+set -e
+
 trap "exit" INT
 
 # Load Libraries


### PR DESCRIPTION
Blacklist the generation of arm64 for non supported checks.
- semgrep: https://github.com/returntocorp/semgrep/blob/b9d235886faf1448cc0763e9fcedfa87a4ecbb0a/cli/src/semgrep/cli.py#L50 
- zap: base image not available
- prowler: base image not available