### PR TITLE
Use container openssl available in all architectures

### DIFF
--- a/cmd/vulcan-tls/main.go
+++ b/cmd/vulcan-tls/main.go
@@ -53,10 +53,6 @@ type failure struct {
 	Issues []string
 }
 
-type analyzeRunner struct {
-	result *result
-}
-
 func main() {
 	run := func(ctx context.Context, target, assetType, optJSON string, state checkstate.State) error {
 		logger := check.NewCheckLog(name)
@@ -99,6 +95,7 @@ func main() {
 			"python",
 			[]string{
 				analyzePath,
+				"-o", "/usr/bin/openssl",
 				"-l", "modern",
 				"-t", target,
 				"-j",
@@ -117,12 +114,12 @@ func main() {
 
 		// Classify failures by risk on TLS security and severity.
 		failures := []failure{
-			failure{
+			{
 				"minimally secure",
 				report.SeverityThresholdMedium,
 				res.Analysis.Failures.Vulnerable,
 			},
-			failure{
+			{
 				"highly secure",
 				report.SeverityThresholdLow,
 				res.Analysis.Failures.Modern,


### PR DESCRIPTION
The check relies on `openssl` binaries from https://github.com/mozilla/cipherscan, old version and only available for Darwin or amd64 (not arm64)
This pr forces the use of the openssl version in `python:3.7-slim`

Upgrades the pretty old openssl version
```sh
# ./openssl version
OpenSSL 1.0.2-chacha (1.0.2i-dev)
# openssl version
OpenSSL 1.1.1n  15 Mar 2022
```
