### PR TITLE
Set trivy timeout

### DIFF
--- a/cmd/vulcan-trivy/manifest.toml
+++ b/cmd/vulcan-trivy/manifest.toml
@@ -1,4 +1,5 @@
 Description = "Scan docker images and Git repositories using aquasec/trivy"
+Timeout = 300
 AssetTypes = ["DockerImage", 
     # "GitRepository"
 ]


### PR DESCRIPTION
Set trivy checks timeout.
If not specified Vulcan-agent defaults to what's configured and in the case of trivy that default could be too much restrictive provided the timeout includes the pull time.