### PR TITLE
Fix Nuclei flag error and set conservative templates

### DIFF
--- a/cmd/vulcan-nuclei/Dockerfile
+++ b/cmd/vulcan-nuclei/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright 2022 Adevinta
 
-FROM projectdiscovery/nuclei:latest
+FROM projectdiscovery/nuclei:v2.8.3
 ENTRYPOINT []
 
 WORKDIR /

--- a/cmd/vulcan-nuclei/main.go
+++ b/cmd/vulcan-nuclei/main.go
@@ -283,7 +283,6 @@ func buildNucleiScanCmdArgs(target string, severities []string) []string {
 		"-json",
 		"-silent",
 		"-no-meta",
-		"-no-timestamp",
 		"-H", userAgent,
 	}
 

--- a/cmd/vulcan-nuclei/manifest.toml
+++ b/cmd/vulcan-nuclei/manifest.toml
@@ -2,6 +2,8 @@
 
 Description = "Scan web addresses with projectdiscovery/nuclei"
 AssetTypes = ["WebAddress", "Hostname"]
+Options = '{"template_inclusion_list": ["misconfiguration", "default-logins", "exposed-panels", "exposures", "dns", "takeovers"]}'
+
 # skip_update_templates: You can specify whether to skip updating vulcan-nuclei templates
 #                        or not from source repository. Default is false.
 # template_inclusion_list: You can specify which nuclei templates will run against the target.


### PR DESCRIPTION
This PR fixes an error with a [deprecated Nuclei flag](https://github.com/projectdiscovery/nuclei/pull/2962), pins the current version to avoid future breakages and enables a limited list of conservative templates so that the check can be included in the default Vulcan policy. Further templates can be included in more aggressive policies or for specific assets by adding them through options or removing the whitelist option altogether.