### PR TITLE
Fix unmarshall error

### DIFF
--- a/cmd/vulcan-nuclei/nuclei.go
+++ b/cmd/vulcan-nuclei/nuclei.go
@@ -7,14 +7,14 @@ package main
 import "time"
 
 type Info struct {
-	Name           string            `json:"name,omitempty"`
-	Description    string            `json:"description,omitempty"`
-	Metadata       map[string]string `json:"metadata,omitempty"`
-	Reference      []string          `json:"reference,omitempty"`
-	Tags           []string          `json:"tags,omitempty"`
-	Remediation    string            `json:"remediation,omitempty"`
-	Severity       string            `json:"severity,omitempty"`
-	Classification Classification    `json:"classification,omitempty"`
+	Name           string                 `json:"name,omitempty"`
+	Description    string                 `json:"description,omitempty"`
+	Metadata       map[string]interface{} `json:"metadata,omitempty"`
+	Reference      []string               `json:"reference,omitempty"`
+	Tags           []string               `json:"tags,omitempty"`
+	Remediation    string                 `json:"remediation,omitempty"`
+	Severity       string                 `json:"severity,omitempty"`
+	Classification Classification         `json:"classification,omitempty"`
 }
 
 type ResultEvent struct {


### PR DESCRIPTION
Fixes this error: `cannot unmarshal bool into Go struct field Info.info.metadata of type string`

```json
{
  "template": "technologies/pypiserver-detect.yaml",
  "template-url": "https://github.com/projectdiscovery/nuclei-templates/blob/master/technologies/pypiserver-detect.yaml",
  "template-id": "pypiserver-detect",
  "info": {
    "name": "PyPI Server Detect",
    "author": [
      "ritikchaddha"
    ],
    "tags": [
      "tech",
      "pypiserver"
    ],
    "reference": null,
    "severity": "info",
    "metadata": {
      "verified": true,
      "shodan-query": "html:\"pypiserver\""
    }
  },
  "type": "http",
  "host": "https://www.google.com/",
  "matched-at": "https://www.google.com/",
  "ip": "142.250.184.164",
  "timestamp": "2022-12-15T17:33:13.249765+01:00",
  "curl-command": "curl -X 'GET' -d '' -H 'Accept: */*' -H 'Accept-Language: en' -H 'User-Agent: Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2224.3 Safari/537.36' 'https://www.google.com/'",
  "matcher-status": true,
  "matched-line": null
}
```