### PR TITLE
upgrade trivy

### DIFF
--- a/cmd/vulcan-trivy/Dockerfile
+++ b/cmd/vulcan-trivy/Dockerfile
@@ -6,7 +6,7 @@ FROM aquasec/trivy:0.41.0
 RUN apk add --no-cache rpm && \
     trivy --quiet image --download-db-only && \
     trivy --quiet image --download-java-db-only && \
-    find /root/.cache -name "*.db" -print -exec gzip {} \;
+    find /root/.cache -name "NOTHING*.db" -print -exec gzip {} \;
 
 WORKDIR /
 

--- a/cmd/vulcan-trivy/Dockerfile
+++ b/cmd/vulcan-trivy/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright 2020 Adevinta
 
-FROM aquasec/trivy:0.38.2
+FROM aquasec/trivy:0.40.0
 
 # Required for scanning RHEL/CentOS images
 RUN apk add rpm

--- a/cmd/vulcan-trivy/Dockerfile
+++ b/cmd/vulcan-trivy/Dockerfile
@@ -1,12 +1,12 @@
 # Copyright 2020 Adevinta
 
-FROM aquasec/trivy:0.38.1
+FROM aquasec/trivy:0.38.2
 
 # Required for scanning RHEL/CentOS images
 RUN apk add rpm
 
 RUN trivy --quiet image --download-db-only && \
-#    trivy --quiet image --download-java-db-only && \
+    trivy --quiet image --download-java-db-only && \
     find /root/.cache -name "*.db" -print -exec gzip {} \;
 
 WORKDIR /

--- a/cmd/vulcan-trivy/Dockerfile
+++ b/cmd/vulcan-trivy/Dockerfile
@@ -5,8 +5,10 @@ FROM aquasec/trivy:0.41.0
 # Required for scanning RHEL/CentOS images
 RUN apk add --no-cache rpm && \
     trivy --quiet image --download-db-only && \
-    trivy --quiet image --download-java-db-only && \
-    find /root/.cache -name "NOTHING*.db" -print -exec gzip {} \;
+    trivy --quiet image --download-java-db-only
+
+# Skip as it's time consuming to unzip and increases the size of the container (not the image)
+# RUN find /root/.cache -name "*.db" -print -exec gzip {} \;
 
 WORKDIR /
 

--- a/cmd/vulcan-trivy/Dockerfile
+++ b/cmd/vulcan-trivy/Dockerfile
@@ -3,9 +3,8 @@
 FROM aquasec/trivy:0.41.0
 
 # Required for scanning RHEL/CentOS images
-RUN apk add rpm
-
-RUN trivy --quiet image --download-db-only && \
+RUN apk add --no-cache rpm && \
+    trivy --quiet image --download-db-only && \
     trivy --quiet image --download-java-db-only && \
     find /root/.cache -name "*.db" -print -exec gzip {} \;
 

--- a/cmd/vulcan-trivy/Dockerfile
+++ b/cmd/vulcan-trivy/Dockerfile
@@ -1,22 +1,20 @@
 # Copyright 2020 Adevinta
 
-FROM aquasec/trivy:0.33.0 as dependency_builder
-
-ENV TRIVY_CACHE_DIR=/trivy_cache
-
-RUN mkdir $TRIVY_CACHE_DIR && \
-    trivy --quiet image --download-db-only && \
-    tar cvfz trivy_cache.tgz ${TRIVY_CACHE_DIR}
-
-FROM alpine
+FROM aquasec/trivy:0.38.1
 
 # Required for scanning RHEL/CentOS images
 RUN apk add rpm
+
+RUN trivy --quiet image --download-db-only && \
+    trivy --quiet image --download-java-db-only && \
+    tar cvzf /root/cache.tgz -C /root .cache && \
+    rm -rf /root/.cache
+
 WORKDIR /
-ENV TRIVY_CACHE_DIR=/trivy_cache
-COPY --from=dependency_builder /usr/local/bin/trivy trivy_cache.tgz /
+
 ARG TARGETOS TARGETARCH
 COPY ${TARGETOS}/${TARGETARCH}/vulcan-trivy /
 COPY entrypoint.sh /
 COPY config/secret.yaml /
 CMD ["/entrypoint.sh"]
+ENTRYPOINT []

--- a/cmd/vulcan-trivy/Dockerfile
+++ b/cmd/vulcan-trivy/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright 2020 Adevinta
 
-FROM aquasec/trivy:0.40.0
+FROM aquasec/trivy:0.41.0
 
 # Required for scanning RHEL/CentOS images
 RUN apk add rpm

--- a/cmd/vulcan-trivy/Dockerfile
+++ b/cmd/vulcan-trivy/Dockerfile
@@ -6,9 +6,8 @@ FROM aquasec/trivy:0.38.1
 RUN apk add rpm
 
 RUN trivy --quiet image --download-db-only && \
-    trivy --quiet image --download-java-db-only && \
-    tar cvzf /root/cache.tgz -C /root .cache && \
-    rm -rf /root/.cache
+#    trivy --quiet image --download-java-db-only && \
+    find /root/.cache -name "*.db" -print -exec gzip {} \;
 
 WORKDIR /
 

--- a/cmd/vulcan-trivy/entrypoint.sh
+++ b/cmd/vulcan-trivy/entrypoint.sh
@@ -5,8 +5,8 @@
 set -e
 
 if [ -d /root/.cache ]; then
-    find /root/.cache/ -name "*.gz" -exec gunzip {} \;
+    time find /root/.cache/ -name "*.gz" -print -exec gunzip {} \;
 fi
 
 # run check
-./vulcan-trivy "$@"
+exec ./vulcan-trivy "$@"

--- a/cmd/vulcan-trivy/entrypoint.sh
+++ b/cmd/vulcan-trivy/entrypoint.sh
@@ -5,7 +5,8 @@
 set -e
 
 # untar trivy cache file
-tar xf trivy_cache.tgz
+tar xvf /root/cache.tgz -C /root
+rm /root/cache.tgz
 
 # run check
 ./vulcan-trivy "$@"

--- a/cmd/vulcan-trivy/entrypoint.sh
+++ b/cmd/vulcan-trivy/entrypoint.sh
@@ -4,9 +4,7 @@
 
 set -e
 
-# untar trivy cache file
-tar xvf /root/cache.tgz -C /root
-rm /root/cache.tgz
+find /root/.cache/ -name "*.gz" -exec gunzip {} \;
 
 # run check
 ./vulcan-trivy "$@"

--- a/cmd/vulcan-trivy/entrypoint.sh
+++ b/cmd/vulcan-trivy/entrypoint.sh
@@ -4,7 +4,9 @@
 
 set -e
 
-find /root/.cache/ -name "*.gz" -exec gunzip {} \;
+if [ -d /root/.cache ]; then
+    find /root/.cache/ -name "*.gz" -exec gunzip {} \;
+fi
 
 # run check
 ./vulcan-trivy "$@"

--- a/cmd/vulcan-trivy/vulcan-trivy.go
+++ b/cmd/vulcan-trivy/vulcan-trivy.go
@@ -182,7 +182,7 @@ func run(ctx context.Context, target, assetType, optJSON string, state checkstat
 	trivyArgs := []string{}
 	// Skip vulnerability db update if not explicitly forced.
 	if !opt.ForceUpdateDB {
-		trivyArgs = append(trivyArgs, "--skip-update")
+		trivyArgs = append(trivyArgs, "--skip-db-update", "--skip-java-db-update")
 	}
 	if opt.OfflineScan {
 		trivyArgs = append(trivyArgs, "--offline-scan")
@@ -202,7 +202,7 @@ func run(ctx context.Context, target, assetType, optJSON string, state checkstat
 			logger.Warnf("No checks enabled for DockerImage, falling to scan only vuln")
 			sc = "vuln"
 		}
-		trivyArgs = append(trivyArgs, []string{"--security-checks", sc}...)
+		trivyArgs = append(trivyArgs, []string{"--scanners", sc}...)
 
 		// Load required env vars for docker registry authentication.
 		registryEnvDomain := os.Getenv("REGISTRY_DOMAIN")
@@ -296,7 +296,7 @@ func run(ctx context.Context, target, assetType, optJSON string, state checkstat
 			logger.Warnf("No checks enabled for GitRepository")
 			return nil
 		}
-		trivyArgs = append(trivyArgs, []string{"--security-checks", sc}...)
+		trivyArgs = append(trivyArgs, []string{"--scanners", sc}...)
 
 		// Define custom secret config when scanning secrets.
 		if opt.GitChecks.Secret && !opt.DisableCustomSecretConfig {
@@ -370,7 +370,7 @@ func run(ctx context.Context, target, assetType, optJSON string, state checkstat
 
 func execTrivy(opt options, action string, actionArgs []string) (*results, error) {
 	// Build trivy command with arguments.
-	trivyCmd := "./trivy"
+	trivyCmd := "trivy"
 	trivyArgs := []string{
 		action,
 		"-f", "json",

--- a/cmd/vulcan-trivy/vulcan-trivy.go
+++ b/cmd/vulcan-trivy/vulcan-trivy.go
@@ -182,7 +182,7 @@ func run(ctx context.Context, target, assetType, optJSON string, state checkstat
 	trivyArgs := []string{}
 	// Skip vulnerability db update if not explicitly forced.
 	if !opt.ForceUpdateDB {
-		trivyArgs = append(trivyArgs, "--skip-db-update", "--skip-java-db-update")
+		trivyArgs = append(trivyArgs, "--skip-db-update") // "--skip-java-db-update"
 	}
 	if opt.OfflineScan {
 		trivyArgs = append(trivyArgs, "--offline-scan")

--- a/cmd/vulcan-trivy/vulcan-trivy.go
+++ b/cmd/vulcan-trivy/vulcan-trivy.go
@@ -182,7 +182,7 @@ func run(ctx context.Context, target, assetType, optJSON string, state checkstat
 	trivyArgs := []string{}
 	// Skip vulnerability db update if not explicitly forced.
 	if !opt.ForceUpdateDB {
-		trivyArgs = append(trivyArgs, "--skip-db-update") // "--skip-java-db-update"
+		trivyArgs = append(trivyArgs, "--skip-db-update", "--skip-java-db-update")
 	}
 	if opt.OfflineScan {
 		trivyArgs = append(trivyArgs, "--offline-scan")


### PR DESCRIPTION
- Upgrade trivy to latest version
- Use the aquasec/trivy:0.41.0 image as it's an updated alpine image
- Use scanners parameter
- Use find gzip/gunzip
- `TRIVY_CACHE_DIR` seems no longer supported. Using /root/.cache
- Use trivy base image (alpine)

## Cache new java db

- It is required if trivy detects jar (in images) files or java source code.
- It increases the size of the image in 450mb :(
- Not adding this will make the use of vulcan-local download the db avery time they execute
- For vulcan SaaS it could lead to many downloads in the agents.
- Caching also has the penalty of having to decompress it even if it's not used.

This new approach doesn't fit very well in our checks approach, I would like not have to upgrade trivy, but 
I think we want to keep our checks up-to-date.

One solution could be to introduce a mechanism for a check to ask for a cache directory

- Vulcan-agent/vulcan-local would mount the same host folder for all the executions of the check.

# Scenarios

Scanning an image with jars inside

## Case 1 - no cache - image size 230MB

Example trivy downloading the whole db (1m8s - 423MB). This is not acceptable for a developer that has to run many times the checks, or for the agents.

```sh
/ # trivy image adevinta/vulcan-api:edge
2023-04-27T13:18:36.775Z        INFO    Need to update DB
2023-04-27T13:18:36.775Z        INFO    DB Repository: ghcr.io/aquasecurity/trivy-db
2023-04-27T13:18:36.775Z        INFO    Downloading DB...
36.51 MiB / 36.51 MiB [------------------------------------------------------------------------] 100.00% 5.83 MiB p/s 6.5s
2023-04-27T13:18:44.922Z        INFO    Vulnerability scanning is enabled
2023-04-27T13:18:44.922Z        INFO    Secret scanning is enabled
2023-04-27T13:18:44.922Z        INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-04-27T13:18:44.922Z        INFO    Please see also https://aquasecurity.github.io/trivy/v0.40/docs/secret/scanning/#recommendation for faster secret detection
2023-04-27T13:18:49.853Z        INFO    JAR files found
2023-04-27T13:18:49.854Z        INFO    Java DB Repository: ghcr.io/aquasecurity/trivy-java-db:1
2023-04-27T13:18:49.854Z        INFO    Downloading the Java DB...
423.42 MiB / 423.42 MiB [-------------------------------------------------------------------------------------------------------------------] 100.00% 6.22 MiB p/s 1m8s
2023-04-27T13:20:04.299Z        INFO    The Java DB is cached for 3 days. If you want to update the database more frequently, the '--reset' flag clears the DB cache.
2023-04-27T13:20:04.300Z        INFO    Analyzing JAR files takes a while...
2023-04-27T13:20:04.486Z        INFO    Detected OS: alpine
2023-04-27T13:20:04.486Z        INFO    Detecting Alpine vulnerabilities...
2023-04-27T13:20:04.492Z        INFO    Number of language-specific files: 2
2023-04-27T13:20:04.492Z        INFO    Detecting gobinary vulnerabilities...
2023-04-27T13:20:04.494Z        INFO    Detecting jar vulnerabilities...
```

## Case 2 - All cached and zipped - image size 720MB

For every scan it has to unzip the caches:
- Time 10s penalty decompressing event if it doesn't use it.
- Size: It consumes 1GB space on every container. (ie. the agent running 10 trivy checs -> 10gb)

## Case 3 - All cached uncompressed - image size 1.3gb

- Time downloading the image (penalty for CI/CD not caching)
- No penalty decompressing
- No extra usage per container

## Comparing in github actions

two passes <https://github.mpi-internal.com/spt-security/vulcan-local-demo/runs/4405336?check_suite_focus=true>

| image  | size  | pull  | run     | total pass 1 | total  pass2 |
|--------|-------|-------|---------|-------|-----|
| edge   | 259M  | 4.1s  | 5.2 0.7 |   20    | 11 |
| full   | 1.33G | 13.0s | 6.1 3.1 |    31   | 10 |
| zipped | 716M  | 9.0s  | 10 1.4  |    37   |  23 |


# Conclussions

The option of downloading everything is unacceptable. Too much time on every execution.
I would go for one of the other two.

