### PR TITLE
fix retirejs

### DIFF
--- a/cmd/vulcan-retirejs/Dockerfile
+++ b/cmd/vulcan-retirejs/Dockerfile
@@ -3,7 +3,10 @@
 FROM node:alpine
 RUN apk add --no-cache ca-certificates
 RUN yarn global add retire
-ADD https://raw.githubusercontent.com/RetireJS/retire.js/master/repository/jsrepository.json /jsrepository.json
+
+# Execute in /app to prevent retire to walk trough / and fail.
+WORKDIR /app   
+ADD https://raw.githubusercontent.com/RetireJS/retire.js/master/repository/jsrepository.json /app/jsrepository.json
 ARG TARGETOS TARGETARCH
-COPY ${TARGETOS}/${TARGETARCH}/vulcan-retirejs /
-CMD ["/vulcan-retirejs"]
+COPY ${TARGETOS}/${TARGETARCH}/vulcan-retirejs /app
+CMD ["/app/vulcan-retirejs"]

--- a/cmd/vulcan-retirejs/main.go
+++ b/cmd/vulcan-retirejs/main.go
@@ -40,7 +40,6 @@ var (
 	retireArgs = []string{
 		"retire",
 		"--exitwith", "0",
-		"--js",
 		"--outputformat", "json",
 		"--jspath", jsPath,
 		"--jsrepo", "jsrepository.json",

--- a/cmd/vulcan-retirejs/main.go
+++ b/cmd/vulcan-retirejs/main.go
@@ -103,12 +103,14 @@ func scanTarget(ctx context.Context, target, assetType string, logger *logrus.En
 }
 
 func runRetireJs(ctx context.Context, args []string) ([]RetireJsFileResult, error) {
-	if args == nil || len(args) == 0 {
+	if len(args) == 0 {
 		args = retireArgs
 	}
 	var report RetireJsReport
 	_, err := command.ExecuteAndParseJSON(ctx, logger, &report, args[0], args[1:]...)
-
+	if perr, ok := (err).(*command.ParseError); ok {
+		logger.Errorf("errOutput:%s", perr.ProcessErrOutput)
+	}
 	return report.Data, err
 }
 
@@ -123,7 +125,7 @@ func addVulnsToState(state checkstate.State, r []RetireJsFileResult) {
 				Description: "Vulnerabilities in dependencies may impact in the security of your program. For that reason " +
 					"it's important to check for issues not only in your code but in the 3rd party code you are using as a dependency.",
 				Recommendations: []string{
-					fmt.Sprintf("Check if there is an update available for the affected resource."),
+					"Check if there is an update available for the affected resource.",
 					"Additional vulnerability information can be found in the links in the resources table.",
 				},
 				References:       []string{"https://portswigger.net/kb/issues/00500080_vulnerable-javascript-dependency"},


### PR DESCRIPTION
- fix retire error traversing /

```sh
Exception caught: Error: ENOENT: no such file or directory, lstat '/proc/1/ns/cgroup:[4026533078]'
 at Object.realpathSync (node:fs:2588:7)
```

- Remove deprecated parameter --json
- Show errOutput on ParseError to help diagnose problems
