### PR TITLE
Fix retirejs install with yarn arm64

### DIFF
--- a/cmd/vulcan-retirejs/Dockerfile
+++ b/cmd/vulcan-retirejs/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM node:alpine
 RUN apk add --no-cache ca-certificates
-RUN yarn global add retire
+RUN npm install -g retire
 
 # Execute in /app to prevent retire to walk trough / and fail.
 WORKDIR /app   


### PR DESCRIPTION
The build process failed with yarn in arm64.

```
> [linux/arm64 3/5] RUN yarn global add retire:
#16 3.513 yarn global v1.22.19
#16 4.293 [1/4] Resolving packages...
#16 9.938 error Couldn't find package "pac-proxy-agent@^5.0.0" required by "proxy-agent@^5.0.0" on the "npm" registry.
#16 9.941 info Visit https://yarnpkg.com/en/docs/cli/global for documentation about this command.
------
Dockerfile:5
--------------------
   3 |     FROM node:alpine
   4 |     RUN apk add --no-cache ca-certificates
   5 | >>> RUN yarn global add retire
   6 |     ADD https://raw.githubusercontent.com/RetireJS/retire.js/master/repository/jsrepository.json /jsrepository.json
   7 |     ARG TARGETOS TARGETARCH
--------------------
ERROR: failed to solve: process "/bin/sh -c yarn global add retire" did not complete successfully: exit code: 1
```

This pr changes to the proposed install process that seems to work https://github.com/RetireJS/retire.js#command-line-scanner. 