### PR TITLE
Enable secret scanning for GitRepository asset type

### DIFF
--- a/cmd/vulcan-trivy/Dockerfile
+++ b/cmd/vulcan-trivy/Dockerfile
@@ -18,4 +18,5 @@ COPY --from=dependency_builder /usr/local/bin/trivy trivy_cache.tgz /
 ARG TARGETOS TARGETARCH
 COPY ${TARGETOS}/${TARGETARCH}/vulcan-trivy /
 COPY entrypoint.sh /
+COPY config/secret.yaml /
 CMD ["/entrypoint.sh"]

--- a/cmd/vulcan-trivy/config/secret.yaml
+++ b/cmd/vulcan-trivy/config/secret.yaml
@@ -1,0 +1,29 @@
+## jwt-token rule is disabled to reduce false positives.
+## rules:
+#   # Rule for including JWT tokens as secrets.
+#   # Rule source: https://github.com/aquasecurity/trivy/discussions/2496
+#   - id: jwt-token
+#     category: Generic
+#     title: JWT token
+#     severity: HIGH
+#     description:
+#     regex: '["'']?(?P<secret>eyJ[A-Za-z0-9_=-]{2,}\.[A-Za-z0-9_=-]{2,}\.[A-Za-z0-9_.+\/=-]{2,})["'']?'
+#     secret-group-name: secret
+allow-rules:
+  # Skip swagger files to reduce false positives.
+  - id: skip-swagger
+    description: skip swagger files
+    path: swagger.*
+  # Skip rst files to reduce false positives.
+  - id: skip-rst
+    description: skip rst files
+    path: .*\.rst
+disable-rules:
+  # Disable cloud provider account user IDs as they are not secrets perse.
+  - alibaba-access-key-id
+  - aws-account-id
+  - aws-access-key-id
+  # Disable private-key rule is disabled to reduce false positives.
+  - private-key
+  # This is meant to reside at client side, therefore should not be considered a secret.
+  - stripe-publishable-token

--- a/cmd/vulcan-trivy/local.toml.example
+++ b/cmd/vulcan-trivy/local.toml.example
@@ -21,5 +21,6 @@ AssetType = "DockerImage"
 #         "vuln": true,
 #         "secret": false,
 #         "config": false
-#     }
+#     },
+#     "disable_custom_secret_config": false
 # }"""

--- a/cmd/vulcan-trivy/manifest.toml
+++ b/cmd/vulcan-trivy/manifest.toml
@@ -19,5 +19,6 @@ Options = """{
         "vuln": true,
         "secret": false,
         "config": false
-    }
+    },
+    "disable_custom_secret_config": false
 }"""

--- a/cmd/vulcan-trivy/manifest.toml
+++ b/cmd/vulcan-trivy/manifest.toml
@@ -1,5 +1,5 @@
 Description = "Scan docker images and Git repositories using aquasec/trivy"
-Timeout = 300
+Timeout = 900
 AssetTypes = ["DockerImage", 
     "GitRepository"
 ]

--- a/cmd/vulcan-trivy/manifest.toml
+++ b/cmd/vulcan-trivy/manifest.toml
@@ -1,18 +1,18 @@
 Description = "Scan docker images and Git repositories using aquasec/trivy"
 Timeout = 300
 AssetTypes = ["DockerImage", 
-    # "GitRepository"
+    "GitRepository"
 ]
 RequiredVars = [
     "REGISTRY_DOMAIN", "REGISTRY_USERNAME", "REGISTRY_PASSWORD", 
-    # "GITHUB_ENTERPRISE_ENDPOINT", "GITHUB_ENTERPRISE_TOKEN"
+    "GITHUB_ENTERPRISE_ENDPOINT", "GITHUB_ENTERPRISE_TOKEN"
 ]
 Options = """{
     "depth": 1,
     "branch":"",
     "git_checks": {
-        "vuln": true,
-        "secret": false,
+        "vuln": false,
+        "secret": true,
         "config": false
     },
     "image_checks": {

--- a/cmd/vulcan-trivy/vulcan-trivy.go
+++ b/cmd/vulcan-trivy/vulcan-trivy.go
@@ -343,15 +343,15 @@ func run(ctx context.Context, target, assetType, optJSON string, state checkstat
 			}
 
 			vuln = report.Vulnerability{
-				Summary:       "Secret Leaked in Git Repository",
+				Summary:       "Secret leaked in Git Repository",
 				Description:   "A secret has been found stored in the Git repository. This secret may be in any historical commit and could be retrieved by anyone with read access to the repository. Test data and false positives can be marked as such.",
 				CWEID:         540,
 				Score:         8.9,
 				ImpactDetails: "Anyone with access to the repository could retrieve the leaked secret and use it in the future with malicious intent.",
-				Labels:        []string{"issue"},
+				Labels:        []string{"issue", "secret"},
 				Recommendations: []string{
 					"Completely remove the secrets from the repository as explained in the references.",
-					"Encrypt the secrets using a tool like AWS Secrets Manager or Vault.",
+					"It is recommended to utilize a tool such as AWS Secrets Manager or Vault, or follow the guidance provided by your CI/CD provider, to securely store confidential information.",
 				},
 				References: []string{
 					"https://help.github.com/en/articles/removing-sensitive-data-from-a-repository",

--- a/cmd/vulcan-trivy/vulcan-trivy.go
+++ b/cmd/vulcan-trivy/vulcan-trivy.go
@@ -343,7 +343,7 @@ func run(ctx context.Context, target, assetType, optJSON string, state checkstat
 			}
 
 			vuln = report.Vulnerability{
-				Summary:       "Secret leaked in Git Repository",
+				Summary:       "Secret Leaked In Git Repository",
 				Description:   "A secret has been found stored in the Git repository. This secret may be in any historical commit and could be retrieved by anyone with read access to the repository. Test data and false positives can be marked as such.",
 				CWEID:         540,
 				Score:         8.9,

--- a/cmd/vulcan-trivy/vulcan-trivy.go
+++ b/cmd/vulcan-trivy/vulcan-trivy.go
@@ -63,6 +63,8 @@ type options struct {
 	Branch        string `json:"branch"`
 	GitChecks     checks `json:"git_checks"`
 	ImageChecks   checks `json:"image_checks"`
+
+	DisableCustomSecretConfig bool `json:"disable_custom_secret_config"`
 }
 
 // TODO: Replace with "github.com/aquasecurity/trivy/pkg/types"
@@ -295,6 +297,11 @@ func run(ctx context.Context, target, assetType, optJSON string, state checkstat
 			return nil
 		}
 		trivyArgs = append(trivyArgs, []string{"--security-checks", sc}...)
+
+		// Define custom secret config when scanning secrets.
+		if opt.GitChecks.Secret && !opt.DisableCustomSecretConfig {
+			trivyArgs = append(trivyArgs, []string{"--secret-config", "secret.yaml"}...)
+		}
 
 		// Increase default (5m) trivy command timeout.
 		trivyArgs = append(trivyArgs, []string{"--timeout", "10m"}...)

--- a/cmd/vulcan-trivy/vulcan-trivy.go
+++ b/cmd/vulcan-trivy/vulcan-trivy.go
@@ -296,6 +296,9 @@ func run(ctx context.Context, target, assetType, optJSON string, state checkstat
 		}
 		trivyArgs = append(trivyArgs, []string{"--security-checks", sc}...)
 
+		// Increase default (5m) trivy command timeout.
+		trivyArgs = append(trivyArgs, []string{"--timeout", "10m"}...)
+
 		if opt.Depth == 0 {
 			opt.Depth = DefaultDepth
 		}


### PR DESCRIPTION
This pull request adds support for scanning GitRepository assets for secrets using Trivy secret scanning feature. The following changes have been made:

- GitRepository asset type is now included as a target for the secret scanning check. This requires the inclusion of the environment variables `GITHUB_ENTERPRISE_ENDPOINT` and `GITHUB_ENTERPRISE_TOKEN`.
- Secret scanning is enabled only for GitRepository assets and not for Docker images.
- Secret scanning is performed with a custom Trivy configuration file by default to reduce false positives.