### PR TITLE
Prevent vulcan-retirejs failing under some circumstances

### DIFF
--- a/cmd/vulcan-retirejs/main.go
+++ b/cmd/vulcan-retirejs/main.go
@@ -376,13 +376,13 @@ func writeFile(fileName string, contents string) error {
 }
 
 func downloadFromUrl(URL string) error {
-	filename := ""
 	u, err := url.ParseRequestURI(URL)
-	if err == nil {
-		path := u.EscapedPath()
-		tokens := strings.Split(strings.Trim(path, "/"), "/")
-		filename = tokens[len(tokens)-1]
+	if err != nil {
+		return fmt.Errorf("error invalid url %s: %w", URL, err)
 	}
+	tokens := strings.Split(strings.Trim(u.EscapedPath(), "/"), "/")
+	filename := tokens[len(tokens)-1]
+
 	// NOTE: a random UUID is appended to avoid file path clashing with other
 	// previously downloaded scripts (e.g. '/a/jquery.min.js' and
 	// '/b/jquery.min.js').

--- a/cmd/vulcan-retirejs/main.go
+++ b/cmd/vulcan-retirejs/main.go
@@ -47,6 +47,17 @@ var (
 	client *http.Client
 )
 
+func init() {
+	timeout := 5 * time.Second
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client = &http.Client{
+		Transport: tr,
+		Timeout:   timeout,
+	}
+}
+
 func main() {
 	run := func(ctx context.Context, target, assetType, optJSON string, state checkstate.State) error {
 		if target == "" {
@@ -70,15 +81,6 @@ func main() {
 }
 
 func scanTarget(ctx context.Context, target, assetType string, logger *logrus.Entry, state checkstate.State, args []string) error {
-	timeout := 5 * time.Second
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-	client = &http.Client{
-		Transport: tr,
-		Timeout:   timeout,
-	}
-
 	target, err := resolveTarget(target, assetType)
 	if err != nil {
 		// Don't fail the check if the target can not be accessed.

--- a/cmd/vulcan-retirejs/main_test.go
+++ b/cmd/vulcan-retirejs/main_test.go
@@ -70,30 +70,6 @@ func TestDownloadFromUrl(t *testing.T) {
 	os.Remove("temp")
 }
 
-func TestGetFilePath(t *testing.T) {
-	var urlToFilePath = []struct {
-		in       string
-		expected string
-	}{
-		{"https://domain.name/scripts/path/jquery.js", "temp/jquery.js"},
-		{"https://domain.name/script/a", "temp/a"},
-		{"https://domain.name/script/", "temp/uuid"},
-		{"https://domain.name/script", "temp/script"},
-	}
-	for _, tt := range urlToFilePath {
-		actual := getFilePath(tt.in)
-		if actual != tt.expected && tt.expected != "temp/uuid" {
-			t.Fatalf("getFilePath(%s): expected: %s, actual: %s", tt.in, tt.expected, actual)
-		}
-
-		if tt.expected == "temp/uuid" && len(actual) != 44 && !strings.HasPrefix(actual, "temp/") {
-			t.Fatalf("getFilePath(%s): expected: %s, actual: %s", tt.in, tt.expected, actual)
-		}
-
-	}
-
-}
-
 func TestGetAffectedVersion(t *testing.T) {
 	var versions = []struct {
 		atOrAbove string


### PR DESCRIPTION
We have detected that `vulcan-retirejs` was failing under some circumstances:

1. While scanning sites with non-valid SSL certificates (expired, self-signed, etc.) (fixed in ffd74f6dc6e62c5dc721fd43e770fe8b9dd9012a)
2. When imported Javascript dependencies had several parameters (fixed in 37e082657ef6d822be1fcca6f68dbc224301e0fd)

This PR addresses those errors.