### PR TITLE
Enable Docker image secret scanning for Trivy

### DIFF
--- a/cmd/vulcan-trivy/config/secret.yaml
+++ b/cmd/vulcan-trivy/config/secret.yaml
@@ -1,3 +1,24 @@
+rules:
+  - id: jfrog-api-key
+    category: JFrog
+    title: JFrog / Artifactory API Key
+    severity: HIGH
+    keywords:
+      - jfrog
+      - artifactory
+      - bintray
+      - xray
+    regex: (?i)(?:jfrog|artifactory|bintray|xray)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{73})(?:['|\"|\n|\r|\s|\x60|;]|$)
+  - id: jfrog-identity-token
+    category: JFrog
+    title: JFrog / Artifactory Identity Token
+    severity: HIGH
+    keywords:
+      - jfrog
+      - artifactory
+      - bintray
+      - xray
+    regex: (?i)(?:jfrog|artifactory|bintray|xray)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)
 ## jwt-token rule is disabled to reduce false positives.
 ## rules:
 #   # Rule for including JWT tokens as secrets.

--- a/cmd/vulcan-trivy/local.toml.example
+++ b/cmd/vulcan-trivy/local.toml.example
@@ -7,8 +7,8 @@ AssetType = "DockerImage"
 
 # example Options
 # Options = """{
-#     "force_update_db": false, 
-#     "ignore_unfixed": false, 
+#     "force_update_db": false,
+#     "ignore_unfixed": false,
 #     "severities":"UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL",
 #     "depth": 1,
 #     "branch":"",
@@ -22,5 +22,6 @@ AssetType = "DockerImage"
 #         "secret": false,
 #         "config": false
 #     },
-#     "disable_custom_secret_config": false
+#     "disable_custom_secret_config": false,
+#     "scan_image_metadata": true
 # }"""

--- a/cmd/vulcan-trivy/manifest.toml
+++ b/cmd/vulcan-trivy/manifest.toml
@@ -21,5 +21,5 @@ Options = """{
         "config": false
     },
     "disable_custom_secret_config": false,
-	"scan_image_metadata": true
+    "scan_image_metadata": true
 }"""

--- a/cmd/vulcan-trivy/manifest.toml
+++ b/cmd/vulcan-trivy/manifest.toml
@@ -1,5 +1,5 @@
 Description = "Scan docker images and Git repositories using aquasec/trivy"
-Timeout = 900
+Timeout = 3600 # 1 hour
 AssetTypes = ["DockerImage",
     "GitRepository"
 ]

--- a/cmd/vulcan-trivy/manifest.toml
+++ b/cmd/vulcan-trivy/manifest.toml
@@ -17,8 +17,9 @@ Options = """{
     },
     "image_checks": {
         "vuln": true,
-        "secret": false,
+        "secret": true,
         "config": false
     },
-    "disable_custom_secret_config": false
+    "disable_custom_secret_config": false,
+	"scan_image_metadata": true,
 }"""

--- a/cmd/vulcan-trivy/manifest.toml
+++ b/cmd/vulcan-trivy/manifest.toml
@@ -1,10 +1,10 @@
 Description = "Scan docker images and Git repositories using aquasec/trivy"
 Timeout = 900
-AssetTypes = ["DockerImage", 
+AssetTypes = ["DockerImage",
     "GitRepository"
 ]
 RequiredVars = [
-    "REGISTRY_DOMAIN", "REGISTRY_USERNAME", "REGISTRY_PASSWORD", 
+    "REGISTRY_DOMAIN", "REGISTRY_USERNAME", "REGISTRY_PASSWORD",
     "GITHUB_ENTERPRISE_ENDPOINT", "GITHUB_ENTERPRISE_TOKEN"
 ]
 Options = """{

--- a/cmd/vulcan-trivy/manifest.toml
+++ b/cmd/vulcan-trivy/manifest.toml
@@ -21,5 +21,5 @@ Options = """{
         "config": false
     },
     "disable_custom_secret_config": false,
-	"scan_image_metadata": true,
+	"scan_image_metadata": true
 }"""

--- a/cmd/vulcan-trivy/vulcan-trivy.go
+++ b/cmd/vulcan-trivy/vulcan-trivy.go
@@ -37,7 +37,7 @@ const (
 	// the `--timeout` flag. The value should be bigger than the check timeout
 	// defined in the manifest, to ensure the check will have a `TIMEOUT`
 	// status when the execution takes longer than expected.
-	trivyTimeout = `2h`
+	trivyTimeout = "2h"
 )
 
 var (

--- a/cmd/vulcan-trivy/vulcan-trivy.go
+++ b/cmd/vulcan-trivy/vulcan-trivy.go
@@ -34,8 +34,8 @@ const (
 	vulnCVETruncateLimit = 10
 	DefaultDepth         = 1
 	// trivyTimeout defines the value that will be passed to the trivy CLI via
-	// the `--timeout` flag. The value should be bigger than the check timeout
-	// defined in the manifest, to ensure the check will have a `TIMEOUT`
+	// the '--timeout' flag. The value should be bigger than the check timeout
+	// defined in the manifest, to ensure the check will have a 'TIMEOUT'
 	// status when the execution takes longer than expected.
 	trivyTimeout = "2h"
 )

--- a/cmd/vulcan-trivy/vulcan-trivy.go
+++ b/cmd/vulcan-trivy/vulcan-trivy.go
@@ -41,7 +41,7 @@ var (
 	reportOutputFile = "report.json"
 	localTargets     = regexp.MustCompile(`https?://(localhost|host\.docker\.internal|172\.17\.0\.1)`)
 
-	FilePatters = []string{
+	FilePatterns = []string{
 		// trivy only detect requirements.txt files
 		`pip:/requirements/[^/]+\.txt`,    // All the .txt files in a requirements directory.
 		`pip:[^/]*requirements[^/]*\.txt`, // All the files .txt that contains requirements
@@ -192,7 +192,7 @@ func run(ctx context.Context, target, assetType, optJSON string, state checkstat
 		trivyArgs = append(trivyArgs, "--ignore-unfixed")
 	}
 
-	for _, p := range FilePatters {
+	for _, p := range FilePatterns {
 		trivyArgs = append(trivyArgs, []string{"--file-patterns", fmt.Sprintf(`"%s"`, p)}...)
 	}
 

--- a/cmd/vulcan-trivy/vulcan-trivy.go
+++ b/cmd/vulcan-trivy/vulcan-trivy.go
@@ -65,6 +65,11 @@ type options struct {
 	ImageChecks   checks `json:"image_checks"`
 
 	DisableCustomSecretConfig bool `json:"disable_custom_secret_config"`
+
+	// ScanImageMetadata enables scanning for secrets in the container image
+	// metadata. For further information check
+	// https://aquasecurity.github.io/trivy/v0.45/docs/target/container_image/
+	ScanImageMetadata bool `json:"scan_image_metadata"`
 }
 
 // TODO: Replace with "github.com/aquasecurity/trivy/pkg/types"
@@ -203,6 +208,9 @@ func run(ctx context.Context, target, assetType, optJSON string, state checkstat
 			sc = "vuln"
 		}
 		trivyArgs = append(trivyArgs, []string{"--scanners", sc}...)
+		if strings.Contains(sc, "secret") && opt.ScanImageMetadata {
+			trivyArgs = append(trivyArgs, []string{"--image-config-scanners", "secret"}...)
+		}
 
 		// Load required env vars for docker registry authentication.
 		registryEnvDomain := os.Getenv("REGISTRY_DOMAIN")

--- a/cmd/vulcan-trivy/vulcan-trivy.go
+++ b/cmd/vulcan-trivy/vulcan-trivy.go
@@ -208,8 +208,14 @@ func run(ctx context.Context, target, assetType, optJSON string, state checkstat
 			sc = "vuln"
 		}
 		trivyArgs = append(trivyArgs, []string{"--scanners", sc}...)
-		if strings.Contains(sc, "secret") && opt.ScanImageMetadata {
-			trivyArgs = append(trivyArgs, []string{"--image-config-scanners", "secret"}...)
+
+		if opt.ImageChecks.Secret {
+			if !opt.DisableCustomSecretConfig {
+				trivyArgs = append(trivyArgs, []string{"--secret-config", "secret.yaml"}...)
+			}
+			if opt.ScanImageMetadata {
+				trivyArgs = append(trivyArgs, []string{"--image-config-scanners", "secret"}...)
+			}
 		}
 
 		// Load required env vars for docker registry authentication.


### PR DESCRIPTION
This PR modifies `vulcan-trivy` to enable docker image secret scanning, including the image metadata, and adds a rule to detect JFrog Artifactory credentials ported from Gitleaks.
