### PR TITLE
go.mod: update github.com/adevinta/vulcan-check-sdk to v1.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/FiloSottile/Heartbleed v0.2.1-0.20150408030656-4a3332ca1dc0
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/adevinta/restuss v1.1.0
-	github.com/adevinta/vulcan-check-sdk v1.0.4
+	github.com/adevinta/vulcan-check-sdk v1.1.0
 	github.com/adevinta/vulcan-report v1.0.0
 	github.com/adevinta/vulcan-types v1.1.1
 	github.com/avast/retry-go v3.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/acomagu/bufpipe v1.0.4 h1:e3H4WUzM3npvo5uv95QuJM3cQspFNtFBzvJ2oNjKIDQ
 github.com/acomagu/bufpipe v1.0.4/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/adevinta/restuss v1.1.0 h1:ufdZrDEaPfY43xNvkughifyybEJ31mN8X5qUvnZp32A=
 github.com/adevinta/restuss v1.1.0/go.mod h1:W4IeLE5TV42aNW+4YHlxQSe3gv2dx8wKPDt3gS/OMCo=
-github.com/adevinta/vulcan-check-sdk v1.0.4 h1:6MZHnLaxYO1LK7XjFZbR18yHJLZ0GlSqXq2X1BKXqeM=
-github.com/adevinta/vulcan-check-sdk v1.0.4/go.mod h1:jH3FkxPy6JkJkBuGwNlRvXCR93sIsrhVCcWBvPIMotU=
+github.com/adevinta/vulcan-check-sdk v1.1.0 h1:SqOWUoTS33HbtsZl8kBXqQ7Ulyp8HDhGZm7e5By78ng=
+github.com/adevinta/vulcan-check-sdk v1.1.0/go.mod h1:gGaCUnW6lCBYMYGn42fZSa0kmVRX/2Uo74C3vyDAG2I=
 github.com/adevinta/vulcan-report v1.0.0 h1:44aICPZ+4svucgCSA5KmjlT3ZGzrvZXiSnkbnj6AC2k=
 github.com/adevinta/vulcan-report v1.0.0/go.mod h1:k34KaeoXc3H77WNMwI9F4F1G28hBjB95PeMUp9oHbEE=
 github.com/adevinta/vulcan-types v1.1.1 h1:JwThbdAPK5YzNLuVu4EnZGpztgv+OYjutBp/TiPHd8g=


### PR DESCRIPTION
This PR updates github.com/adevinta/vulcan-check-sdk to v1.1.0. This
version introduces the runtime flag VULCAN_SKIP_REACHABILITY, which
allows to skip the SDK reachability checks. This is required to run
some Vulcan checks against local targets. For instance, vulcan-trivy
against local Docker images.