### PR TITLE
Fix and improve zap

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,33 +7,27 @@ updates:
   open-pull-requests-limit: 10
   labels:
     - "dependencies"
-  commit-message:
-    prefix: "feat"
-    include: "scope"
 - package-ecosystem: "docker"
   directory: cmd/vulcan-nuclei
   schedule:
     interval: "weekly"
   labels:
     - "dependencies"
-  commit-message:
-    prefix: "feat"
-    include: "scope"
 - package-ecosystem: "docker"
   directory: cmd/vulcan-semgrep
   schedule:
     interval: "weekly"
   labels:
     - "dependencies"
-  commit-message:
-    prefix: "feat"
-    include: "scope"
 - package-ecosystem: "docker"
   directory: cmd/vulcan-trivy
   schedule:
     interval: "weekly"
   labels:
     - "dependencies"
-  commit-message:
-    prefix: "feat"
-    include: "scope"
+- package-ecosystem: "docker"
+  directory: cmd/vulcan-zap
+  schedule:
+    interval: "weekly"
+  labels:
+    - "dependencies"

--- a/cmd/vulcan-zap/Dockerfile
+++ b/cmd/vulcan-zap/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright 2019 Adevinta
 
-FROM owasp/zap2docker-bare:2.13.0
+FROM softwaresecurityproject/zap-bare:2.13.0
 USER root
 RUN chown -R zap /zap/
 

--- a/cmd/vulcan-zap/Dockerfile
+++ b/cmd/vulcan-zap/Dockerfile
@@ -1,11 +1,13 @@
 # Copyright 2019 Adevinta
 
-FROM owasp/zap2docker-bare:latest
-
+FROM owasp/zap2docker-bare:2.13.0
 USER root
 RUN chown -R zap /zap/
 
 USER zap
+
+RUN /zap/zap.sh -cmd -addonupdate -notel
+
 ARG TARGETOS TARGETARCH
 COPY ${TARGETOS}/${TARGETARCH}/vulcan-zap /
 CMD ["/vulcan-zap"]

--- a/cmd/vulcan-zap/main.go
+++ b/cmd/vulcan-zap/main.go
@@ -82,6 +82,7 @@ func main() {
 				"/zap/zap.sh",
 				"-daemon", "-host", "127.0.0.1", "-port", "8080",
 				"-config", "api.disablekey=true",
+				"-config", "database.recoverylog=false", // Reduce disk usage
 			).Output()
 			logger.Debugf("Error executing ZAP daemon: %v", err)
 			logger.Debugf("Output of the ZAP daemon: %s", string(out))

--- a/cmd/vulcan-zap/main.go
+++ b/cmd/vulcan-zap/main.go
@@ -81,7 +81,10 @@ func main() {
 				"-daemon", "-host", "127.0.0.1", "-port", "8080",
 				"-config", "api.disablekey=true",
 				"-config", "database.recoverylog=false", // Reduce disk usage
+				"-notel",  // Disables telemetry
+				"-silent", // Prevents from checking for addon updates
 			).Output()
+
 			logger.Debugf("Error executing ZAP daemon: %v", err)
 			logger.Debugf("Output of the ZAP daemon: %s", string(out))
 

--- a/cmd/vulcan-zap/main.go
+++ b/cmd/vulcan-zap/main.go
@@ -47,7 +47,6 @@ type options struct {
 	MaxSpiderDuration          int      `json:"max_spider_duration"`
 	MaxScanDuration            int      `json:"max_scan_duration"` // In minutes
 	MaxRuleDuration            int      `json:"max_rule_duration"` // In minutes
-	MaxAlertsPerRule           int      `json:"max_alerts_per_rule"`
 	OpenapiUrl                 string   `json:"openapi_url"`
 	OpenapiHost                string   `json:"openapi_host"`
 }
@@ -185,11 +184,6 @@ func main() {
 			return fmt.Errorf("error setting spider max duration: %w", err)
 		}
 
-		// Apply zap_tune optimizations.
-		_, err = client.Pscan().SetMaxAlertsPerRule(strconv.Itoa(opt.MaxAlertsPerRule))
-		if err != nil {
-			return fmt.Errorf("error setting max alerts per rule: %w", err)
-		}
 		_, err = client.Pscan().DisableAllTags()
 		if err != nil {
 			return fmt.Errorf("error disabling all tags: %w", err)

--- a/cmd/vulcan-zap/main.go
+++ b/cmd/vulcan-zap/main.go
@@ -232,7 +232,7 @@ func main() {
 				v, ok := resp["status"]
 				if !ok {
 					// In this case if we can not get the status let's fail.
-					return fmt.Errorf("can not retrieve the status of the spider %v", resp)
+					return fmt.Errorf("cannot retrieve the status of the spider: %v", resp)
 				}
 				status, ok := v.(string)
 				if !ok {
@@ -509,11 +509,11 @@ func isPluginIgnoredForFingerprint(opt options, pluginID string) bool {
 func getStringAttribute(m map[string]any, name string) (string, error) {
 	v, ok := m[name]
 	if !ok {
-		return "", fmt.Errorf("error %s not found", name)
+		return "", fmt.Errorf("%s not found", name)
 	}
 	str, ok := v.(string)
 	if !ok {
-		return "", fmt.Errorf("error %s value [%v] is not a string", name, v)
+		return "", fmt.Errorf("%s value [%v] is not a string", name, v)
 	}
 	return str, nil
 }

--- a/cmd/vulcan-zap/main.go
+++ b/cmd/vulcan-zap/main.go
@@ -50,6 +50,7 @@ type options struct {
 	MaxSpiderDuration          int      `json:"max_spider_duration"`
 	MaxScanDuration            int      `json:"max_scan_duration"`
 	MaxRuleDuration            int      `json:"max_rule_duration"`
+	MaxAlertsPerRule           int      `json:"max_alerts_per_rule"`
 	OpenapiUrl                 string   `json:"openapi_url"`
 	OpenapiHost                string   `json:"openapi_host"`
 }
@@ -178,6 +179,16 @@ func main() {
 		_, err = client.Spider().SetOptionMaxDuration(opt.MaxSpiderDuration)
 		if err != nil {
 			return fmt.Errorf("error setting spider max duration: %w", err)
+		}
+
+		// Apply zap_tune optimizations.
+		_, err = client.Pscan().SetMaxAlertsPerRule(strconv.Itoa(opt.MaxAlertsPerRule))
+		if err != nil {
+			return fmt.Errorf("error setting max alerts per rule: %w", err)
+		}
+		_, err = client.Pscan().DisableAllTags()
+		if err != nil {
+			return fmt.Errorf("error disabling all tags: %w", err)
 		}
 
 		logger.Printf("Running spider %v levels deep, max duration %v, ...", opt.Depth, opt.MaxSpiderDuration)

--- a/cmd/vulcan-zap/main.go
+++ b/cmd/vulcan-zap/main.go
@@ -45,8 +45,8 @@ type options struct {
 	DisabledScanners           []string `json:"disabled_scanners"`
 	IgnoredFingerprintScanners []string `json:"ignored_fingerprint_scanners"`
 	MaxSpiderDuration          int      `json:"max_spider_duration"`
-	MaxScanDuration            int      `json:"max_scan_duration"`
-	MaxRuleDuration            int      `json:"max_rule_duration"`
+	MaxScanDuration            int      `json:"max_scan_duration"` // In minutes
+	MaxRuleDuration            int      `json:"max_rule_duration"` // In minutes
 	MaxAlertsPerRule           int      `json:"max_alerts_per_rule"`
 	OpenapiUrl                 string   `json:"openapi_url"`
 	OpenapiHost                string   `json:"openapi_host"`

--- a/cmd/vulcan-zap/manifest.toml
+++ b/cmd/vulcan-zap/manifest.toml
@@ -8,6 +8,8 @@ Timeout = 36000 # 10 hours. Expressed in seconds as an integer.
 # Ignored scanners for fingerprint:
 # 40018 - SQL Injection - Too many false positive results with variable resources.
 # Source: https://www.zaproxy.org/docs/alerts/
+# max_scan_duration and max_rule_duration are expressed minutes
+# max_scan_duration 9h to allow get results before the 36000 seconds 10h check timeout.
 Options = """{
     "depth": 2, 
     "active": true, 
@@ -15,7 +17,7 @@ Options = """{
     "disabled_scanners": ["10062", "10003", "10108"],
     "ignored_fingerprint_scanners": ["40018"],
     "max_spider_duration": 0,
-    "max_scan_duration": 0, 
+    "max_scan_duration": 540,
     "max_rule_duration": 0,
     "max_alerts_per_rule": 10,
     "openapi_url": "",

--- a/cmd/vulcan-zap/manifest.toml
+++ b/cmd/vulcan-zap/manifest.toml
@@ -17,6 +17,7 @@ Options = """{
     "max_spider_duration": 0,
     "max_scan_duration": 0, 
     "max_rule_duration": 0,
+    "max_alerts_per_rule": 10,
     "openapi_url": "",
     "openapi_host": ""
     }"""

--- a/cmd/vulcan-zap/manifest.toml
+++ b/cmd/vulcan-zap/manifest.toml
@@ -19,7 +19,6 @@ Options = """{
     "max_spider_duration": 0,
     "max_scan_duration": 540,
     "max_rule_duration": 0,
-    "max_alerts_per_rule": 10,
     "openapi_url": "",
     "openapi_host": ""
     }"""

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/yhat/scrape v0.0.0-20161128144610-24b7890b0945
-	github.com/zaproxy/zap-api-go v0.0.0-20200806070313-98cebd2f39ae
+	github.com/zaproxy/zap-api-go v0.0.0-20230809133904-260a8835dee1
 	golang.org/x/net v0.12.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI
 github.com/yhat/scrape v0.0.0-20161128144610-24b7890b0945 h1:6Ju8pZBYFTN9FaV/JvNBiIHcsgEmP4z4laciqjfjY8E=
 github.com/yhat/scrape v0.0.0-20161128144610-24b7890b0945/go.mod h1:4vRFPPNYllgCacoj+0FoKOjTW68rUhEfqPLiEJaK2w8=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/zaproxy/zap-api-go v0.0.0-20200806070313-98cebd2f39ae h1:HB5NPea57rppW36a/QhoMCQ50YQZjMZG+ghUr36uNso=
-github.com/zaproxy/zap-api-go v0.0.0-20200806070313-98cebd2f39ae/go.mod h1:lBqVZ0hGhjkg0sL/0O7IG1QE+kv3sRQMtpKuyZi5llY=
+github.com/zaproxy/zap-api-go v0.0.0-20230809133904-260a8835dee1 h1:t/m9NEamzqUW/i2dUGPYrX3lNHeANSz0actg5Exs9Mc=
+github.com/zaproxy/zap-api-go v0.0.0-20230809133904-260a8835dee1/go.mod h1:M+9bOOP3ffPDcPJ6N8oILPBSUEY/pbhk9emtkt2iHB8=
 golang.org/x/arch v0.1.0/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=


### PR DESCRIPTION
- Improve speed/disk by disabling db recovery log (not a game changer)
  See <https://groups.google.com/g/zaproxy-users/c/L51nDFh0fjk>
- Ugrade github.com/zaproxy/zap-api-go
- Pin [2.13.0](https://www.zaproxy.org/blog/2023-07-12-zap-2.13.0/) and add to dependabot.
- Fix 2.13.0 not working because of add-on updates after server is suposed to be ready.
  ```
  level=warning msg="Scan not present in response body when calling Spider().Scan()" checkID=9f514c48-5d09-11ee-8109-465c9e98cb60"
  ```
- Add optimizations from [`zap_tune`](https://github.com/zaproxy/zaproxy/blob/5dd9a9f5c836d6c1e905265e3adc3e3c07d37467/docker/zap_common.py#L402)
- Setup max_scan_duration to allow the scan to report vulnerabilities before being killed by the agent.