### PR TITLE
Add exposed bgp Nuclei template

### DIFF
--- a/cmd/vulcan-nuclei/local.toml.example
+++ b/cmd/vulcan-nuclei/local.toml.example
@@ -2,7 +2,7 @@
 
 [Check]
 Target = "https://example.com"
-AssetType = "WebAddress"
+AssetTypes = ["WebAddress", "Hostname"]
 # Available options example:
 # Options = """\
 #     {\

--- a/cmd/vulcan-nuclei/templates/network/detection/bgp-detect.yaml
+++ b/cmd/vulcan-nuclei/templates/network/detection/bgp-detect.yaml
@@ -1,0 +1,42 @@
+id: bgp-detect
+
+info:
+  name: Exposed BGP speaker
+  author: Adevinta
+  severity: info
+  tags: network,bgp,detect
+  description: |
+    The remote host is running BGP, a popular routing protocol. This indicates that the remote host is probably a network router.
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cvss-score: 0.0
+    cwe-id: CWE-200
+  reference:
+    - https://www.acunetix.com/vulnerabilities/network/vulnerability/bgp-detection/
+    - https://www.tenable.com/plugins/nessus/11907
+
+tcp:
+  - inputs:
+      - data: FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF001D010400FFFF0000B4C0
+        # Source: https://www.rfc-editor.org/rfc/rfc4271.html#section-4.2
+        # FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF represents the 16-byte marker field.
+        # 001D is the total length of the BGP message, including the 19 bytes of the header and the optional parameters.
+        # 01 is the BGP message type, which is OPEN (1).
+        # 04 represents the BGP version, which is BGP-4.
+        # FFFF represents the Autonomous System Number (ASN) in hexadecimal format.
+        # 0000 represents the Hold Time.
+        # B4C0 represents the BGP Identifier, usually an IP address in hexadecimal format.
+        type: hex
+        name: resp
+
+    host:
+      - "{{Hostname}}"
+      - "{{Host}}:179"
+
+    read-size: 16
+
+    matchers:
+      - type: word
+        encoding: hex
+        words:
+          - "ffffffffffffffffffffffffffffffff"

--- a/cmd/vulcan-nuclei/tests/bgp.bash
+++ b/cmd/vulcan-nuclei/tests/bgp.bash
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 Adevinta
+
+cd "$(dirname "$0")"
+while true; do echo -n -e "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF" | nc -l 179; done


### PR DESCRIPTION
This PR adds a custom Nuclei template to detect exposed BGP services in order to deprecate `vulcan-exposed-bgp` check.