### PR TITLE
vulcan-trivy.go: improve Trivy CLI errors capture

### DIFF
--- a/cmd/vulcan-trivy/entrypoint.sh
+++ b/cmd/vulcan-trivy/entrypoint.sh
@@ -5,7 +5,7 @@
 set -e
 
 if [ -d /root/.cache ]; then
-    time find /root/.cache/ -name "*.gz" -print -exec gunzip {} \;
+    find /root/.cache/ -name "*.gz" -print -exec gunzip {} \;
 fi
 
 # run check


### PR DESCRIPTION
The Trivy CLI returns execution errors as log entries in STDERR even when the json output format is used. In fact the Trivy report data structure does not contain any field to store errors. That makes very hard to capture and process the Trivy CLI errors to be embedded in the 'check.Report.Error' attribute.

This commit tries to improve the situation by applying this changes:
- Reduce the output the Trivy CLI generates just to errors
- Ensure the error returned by the Trivy CLI is the one embedded in the 'check.Report.Error' attribute
- In case of Trivy CLI retries, make the check to log all of them but return just the last one
- Add an error tag to the check logs to make easier to filter logs by them. For example to filter logs by "retry trivy command execution failed"