### PR TITLE
Enable IP AssetType scanning for vulcan-nuclei check

### DIFF
--- a/cmd/vulcan-nuclei/local.toml.example
+++ b/cmd/vulcan-nuclei/local.toml.example
@@ -2,7 +2,7 @@
 
 [Check]
 Target = "https://example.com"
-AssetTypes = ["Hostname", "IP", "WebAddress"]
+AssetType = "WebAddress"
 # Available options example:
 # Options = """\
 #     {\

--- a/cmd/vulcan-nuclei/local.toml.example
+++ b/cmd/vulcan-nuclei/local.toml.example
@@ -2,7 +2,7 @@
 
 [Check]
 Target = "https://example.com"
-AssetType = "WebAddress"
+AssetTypes = ["Hostname", "IP", "WebAddress"]
 # Available options example:
 # Options = """\
 #     {\

--- a/cmd/vulcan-nuclei/manifest.toml
+++ b/cmd/vulcan-nuclei/manifest.toml
@@ -1,7 +1,7 @@
 # Copyright 2022 Adevinta
 
 Description = "Scan web addresses with projectdiscovery/nuclei"
-AssetTypes = ["WebAddress", "Hostname"]
+AssetTypes = ["Hostname", "IP", "WebAddress"]
 Timeout = 1800 # 30 minutes
 Options = '{"tag_exclusion_list": ["intrusive", "dos", "fuzz"]}'
 


### PR DESCRIPTION
This PR enables IP AssetType scanning for vulcan-nuclei check.

For more detail visit internal discussion # 44.