### PR TITLE
vulcan-exposed-db check consolidation using Nuclei

### DIFF
--- a/cmd/vulcan-nuclei/Dockerfile
+++ b/cmd/vulcan-nuclei/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright 2022 Adevinta
 
-FROM projectdiscovery/nuclei:v2.9.10
+FROM projectdiscovery/nuclei:v2.9.15
 ENTRYPOINT []
 
 WORKDIR /

--- a/cmd/vulcan-nuclei/main.go
+++ b/cmd/vulcan-nuclei/main.go
@@ -194,6 +194,7 @@ func processNucleiFindings(target string, nucleiFindings []ResultEvent) []*repor
 			Summary:          v.Info.Name,
 			Description:      v.Info.Description,
 			Details:          generateDetails(target, v.Template),
+			ImpactDetails:    v.Info.Impact,
 			Score:            getScore(v.Info.Severity),
 			References:       v.Info.Reference,
 			Recommendations:  recommendations,

--- a/cmd/vulcan-nuclei/main.go
+++ b/cmd/vulcan-nuclei/main.go
@@ -340,7 +340,7 @@ func buildNucleiScanCmdArgs(target string, opt options) []string {
 	// Exclude selected tags.
 	if len(opt.TagExclusionList) > 0 {
 		etags := strings.Join(opt.TagExclusionList, ",")
-		logger.Infof("included tags: %s", etags)
+		logger.Infof("excluded tags: %s", etags)
 		etagsArg := []string{"-etags", etags}
 		nucleiArgs = append(nucleiArgs, etagsArg...)
 	}

--- a/cmd/vulcan-nuclei/nuclei.go
+++ b/cmd/vulcan-nuclei/nuclei.go
@@ -9,6 +9,7 @@ import "time"
 type Info struct {
 	Name           string                 `json:"name,omitempty"`
 	Description    string                 `json:"description,omitempty"`
+	Impact         string                 `json:"impact,omitempty"`
 	Metadata       map[string]interface{} `json:"metadata,omitempty"`
 	Reference      []string               `json:"reference,omitempty"`
 	Tags           []string               `json:"tags,omitempty"`

--- a/cmd/vulcan-nuclei/templates/network/detection/cassandra-detect.yaml
+++ b/cmd/vulcan-nuclei/templates/network/detection/cassandra-detect.yaml
@@ -1,0 +1,44 @@
+id: cassandra-detect
+
+info:
+  name: Exposed Apache Cassandra database
+  author: adevinta
+  severity: medium
+  description: |
+    Apache Cassandra instance was detected and accessible from the public internet.
+  impact: |
+    An attacker may be able to remotely connect to the database service through the exposed port.
+    If no authentication is implemented, it might be possible to access stored data and, even if authentication is implemented, it may be possible to perform brute force login attempts to access such data.
+    An attacker can also attempt to remotely exploit any vulnerabilities present on the database service to obtain access to the server itself.
+  remediation: |
+    Restrict access to the database service port at the network level.
+  classification:
+    cwe-id: CWE-284
+  tags: network,cassandra,db,detect
+
+network:
+  - inputs:
+      - data: "000000000000000000"
+        type: hex
+
+    host:
+      - "tls://{{Hostname}}"
+    port: 9042
+
+    matchers:
+      - type: word
+        words:
+          - "unsupported protocol version"
+
+  - inputs:
+      - data: "000000000000000000"
+        type: hex
+
+    host:
+      - "{{Hostname}}"
+    port: 9042
+
+    matchers:
+      - type: word
+        words:
+          - "unsupported protocol version"

--- a/cmd/vulcan-nuclei/templates/network/detection/elasticsearch-detect.yaml
+++ b/cmd/vulcan-nuclei/templates/network/detection/elasticsearch-detect.yaml
@@ -1,0 +1,66 @@
+id: elasticsearch-detect
+
+info:
+  name: Exposed Elasticsearch database
+  author: adevinta
+  severity: medium
+  description: |
+    Elasticsearch instance was detected and accessible from the public internet.
+  impact: |
+    An attacker may be able to remotely connect to the database service through the exposed port.
+    If no authentication is implemented, it might be possible to access stored data and, even if authentication is implemented, it may be possible to perform brute force login attempts to access such data.
+    An attacker can also attempt to remotely exploit any vulnerabilities present on the database service to obtain access to the server itself.
+  remediation: |
+    Restrict access to the database service port at the network level.
+  classification:
+    cwe-id: CWE-284
+  tags: network,elasticsearch,db,detect
+
+network:
+  - inputs:
+      - data: "GET /\r\nHost:{{Hostname}}\r\n\r\n"
+
+    host:
+      - "tls://{{Hostname}}"
+    port: 9200
+
+    matchers:
+      - type: word
+        words:
+          - "Elasticsearch"
+
+  - inputs:
+      - data: "GET /\r\nHost:{{Hostname}}\r\n\r\n"
+
+    host:
+      - "{{Hostname}}"
+    port: 9200
+
+    matchers:
+      - type: word
+        words:
+          - "Elasticsearch"
+
+  - inputs:
+      - data: "GET /\r\nHost:{{Hostname}}\r\n\r\n"
+
+    host:
+      - "tls://{{Hostname}}"
+    port: 9300
+
+    matchers:
+      - type: word
+        words:
+          - "Elasticsearch"
+
+  - inputs:
+      - data: "GET /\r\nHost:{{Hostname}}\r\n\r\n"
+
+    host:
+      - "{{Hostname}}"
+    port: 9300
+
+    matchers:
+      - type: word
+        words:
+          - "Elasticsearch"

--- a/cmd/vulcan-nuclei/templates/network/detection/mongodb-detect.yaml
+++ b/cmd/vulcan-nuclei/templates/network/detection/mongodb-detect.yaml
@@ -1,0 +1,63 @@
+id: mongodb-detect
+
+info:
+  name: Exposed MongoDB database
+  author: adevinta
+  severity: medium
+  description: |
+    MongoDB instance was detected and accessible from the public internet.
+  impact: |
+    An attacker may be able to remotely connect to the database service through the exposed port.
+    If no authentication is implemented, it might be possible to access stored data and, even if authentication is implemented, it may be possible to perform brute force login attempts to access such data.
+    An attacker can also attempt to remotely exploit any vulnerabilities present on the database service to obtain access to the server itself.
+  remediation: |
+    Restrict access to the database service port at the network level.
+  classification:
+    cwe-id: CWE-284
+  tags: network,mongodb,db,detect
+
+tcp:
+  - inputs:
+      - data: 3a000000a741000000000000d40700000000000061646d696e2e24636d640000000000ffffffff130000001069736d6173746572000100000000
+        type: hex
+
+    host:
+      - "{{Hostname}}"
+    port: 27017
+    read-size: 2048
+
+    matchers:
+      - type: word
+        words:
+          - "logicalSessionTimeout"
+          - "localTime"
+
+  - inputs:
+      - data: 3a000000a741000000000000d40700000000000061646d696e2e24636d640000000000ffffffff130000001069736d6173746572000100000000
+        type: hex
+
+    host:
+      - "{{Hostname}}"
+    port: 27018
+    read-size: 2048
+
+    matchers:
+      - type: word
+        words:
+          - "logicalSessionTimeout"
+          - "localTime"
+
+  - inputs:
+      - data: 3a000000a741000000000000d40700000000000061646d696e2e24636d640000000000ffffffff130000001069736d6173746572000100000000
+        type: hex
+
+    host:
+      - "{{Hostname}}"
+    port: 27019
+    read-size: 2048
+
+    matchers:
+      - type: word
+        words:
+          - "logicalSessionTimeout"
+          - "localTime"

--- a/cmd/vulcan-nuclei/templates/network/detection/mssql-detect.yaml
+++ b/cmd/vulcan-nuclei/templates/network/detection/mssql-detect.yaml
@@ -1,0 +1,34 @@
+id: mssql-detect
+
+info:
+  name: Exposed MS SQL Server database
+  author: adevinta
+  severity: medium
+  description: |
+    MS SQL Server instance was detected and accessible from the public internet.
+  impact: |
+    An attacker may be able to remotely connect to the database service through the exposed port.
+    If no authentication is implemented, it might be possible to access stored data and, even if authentication is implemented, it may be possible to perform brute force login attempts to access such data.
+    An attacker can also attempt to remotely exploit any vulnerabilities present on the database service to obtain access to the server itself.
+  remediation: |
+    Restrict access to the database service port at the network level.
+  classification:
+    cwe-id: CWE-284
+  tags: network,mssql,db,detect
+
+tcp:
+  - inputs:
+      # sqlcmd_debug connection payload.
+      - data: "1201002f0000010000001a00060100200001020021000103002200040400260001ff00000601000000000000000000"
+        type: hex
+
+    host:
+      - "{{Hostname}}"
+    port: 1433
+
+    read-size: 32
+    matchers:
+      - type: word
+        encoding: hex
+        words:
+          - "0401002b0000010000001a000601002000010200210001030022000004002200"

--- a/cmd/vulcan-nuclei/templates/network/detection/mysql-detect.yaml
+++ b/cmd/vulcan-nuclei/templates/network/detection/mysql-detect.yaml
@@ -1,0 +1,32 @@
+id: mysql-detect
+
+info:
+  name: Exposed MySQL database
+  author: adevinta
+  severity: medium
+  description: |
+    MySQL instance was detected and accessible from the public internet.
+  impact: |
+    An attacker may be able to remotely connect to the database service through the exposed port.
+    If no authentication is implemented, it might be possible to access stored data and, even if authentication is implemented, it may be possible to perform brute force login attempts to access such data.
+    An attacker can also attempt to remotely exploit any vulnerabilities present on the database service to obtain access to the server itself.
+  remediation: |
+    Restrict access to the database service port at the network level.
+  classification:
+    cwe-id: CWE-284
+  tags: network,mysql,db,detect
+
+tcp:
+  - inputs:
+      - data: "\n"
+
+    host:
+      - "{{Hostname}}"
+      - "{{Host}}:3306"
+
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "mysql"
+        case-insensitive: true

--- a/cmd/vulcan-nuclei/templates/network/detection/oracledb-detect.yaml
+++ b/cmd/vulcan-nuclei/templates/network/detection/oracledb-detect.yaml
@@ -1,0 +1,32 @@
+id: oracledb-detect
+
+info:
+  name: Exposed OracleDB database
+  author: adevinta
+  severity: medium
+  description: |
+    OracleDB instance was detected and accessible from the public internet.
+  impact: |
+    An attacker may be able to remotely connect to the database service through the exposed port.
+    If no authentication is implemented, it might be possible to access stored data and, even if authentication is implemented, it may be possible to perform brute force login attempts to access such data.
+    An attacker can also attempt to remotely exploit any vulnerabilities present on the database service to obtain access to the server itself.
+  remediation: |
+    Restrict access to the database service port at the network level.
+  classification:
+    cwe-id: CWE-284
+  tags: network,oracledb,db,detect
+
+tcp:
+  - inputs:
+      # Source: https://github.com/praetorian-inc/fingerprintx/blob/main/pkg/plugins/services/oracledb/oracle.go#L191
+      - data: "00db000001000000013c012c000080007fff7f080000000100a1003a000004000000000000000000000000000000000000000000000000000000284445534352495054494f4e3d28434f4e4e4543545f444154413d28534552564943455f4e414d453d76756c63616e2d6e75636c656929284349443d2850524f4752414d3d76756c63616e2d6e75636c65692928484f53543d76756c63616e2d6e75636c65692928555345523d29292928414444524553533d2850524f544f434f4c3d7463702928484f53543d7461726765742928504f52543d31353231292929"
+        type: hex
+
+    host:
+      - "{{Hostname}}"
+    port: 1521
+
+    matchers:
+      - type: word
+        words:
+          - "(DESCRIPTION=(TMP=)(VSNNUM="

--- a/cmd/vulcan-nuclei/templates/network/detection/pgsql-detect.yaml
+++ b/cmd/vulcan-nuclei/templates/network/detection/pgsql-detect.yaml
@@ -1,0 +1,34 @@
+id: pgsql-detect
+
+info:
+  name: Exposed PostgreSQL database
+  author: adevinta
+  severity: medium
+  description: |
+    PostgreSQL instance was detected and accessible from the public internet.
+  impact: |
+    An attacker may be able to remotely connect to the database service through the exposed port.
+    If no authentication is implemented, it might be possible to access stored data and, even if authentication is implemented, it may be possible to perform brute force login attempts to access such data.
+    An attacker can also attempt to remotely exploit any vulnerabilities present on the database service to obtain access to the server itself.
+  remediation: |
+    Restrict access to the database service port at the network level.
+  classification:
+    cwe-id: CWE-284
+  tags: network,postgresql,db,detect
+
+tcp:
+  - inputs:
+      # pg_isready payload.
+      - data: "0000000804d2162f"
+        type: hex
+
+    host:
+      - "{{Hostname}}"
+    port: 5432
+
+    read-size: 2
+    matchers:
+      - type: word
+        encoding: hex
+        words:
+          - "53"

--- a/cmd/vulcan-nuclei/templates/network/detection/redis-detect.yaml
+++ b/cmd/vulcan-nuclei/templates/network/detection/redis-detect.yaml
@@ -1,0 +1,32 @@
+id: redis-detect
+
+info:
+  name: Exposed Redis database
+  author: adevinta
+  severity: medium
+  description: |
+    Redis instance was detected and accessible from the public internet.
+  impact: |
+    An attacker may be able to remotely connect to the database service through the exposed port.
+    If no authentication is implemented, it might be possible to access stored data and, even if authentication is implemented, it may be possible to perform brute force login attempts to access such data.
+    An attacker can also attempt to remotely exploit any vulnerabilities present on the database service to obtain access to the server itself.
+  remediation: |
+    Restrict access to the database service port at the network level.
+  classification:
+    cwe-id: CWE-284
+  tags: network,redis,detect
+
+tcp:
+  - inputs:
+      - data: "AUTH vulcan-nuclei\r\n"
+
+    host:
+      - "{{Hostname}}"
+    port: 6379
+
+    matchers:
+      - type: word
+        words:
+          - "ERR AUTH"
+          - "ERR Client"
+        condition: or


### PR DESCRIPTION
The goal of this PR is deprecate [vulcan-exposed-db](https://github.com/adevinta/vulcan-checks/tree/master/cmd/vulcan-exposed-db) check in favour of vulcan-nuclei check by providing custom Nuclei templates.
In fact, vulcan-tenable check already report most of the database service exposures but it requires a 3rd party to run and we've decided to provide an open source replacement for the vulcan-exposed-db check instead.

**Check changes:**
- Update check base docker image.
- Add impact attribute to the Nuclei result struct and assign the value to the ImpactDetail Vulcan report.
- Fix a typo when logging excluded template list.

**Templates added:**
- Exposed MySQL
- Exposed PostgreSQL
- Exposed MS SQL Server
- Exposed Redis
- Exposed Elasticsearch
- Exposed MongoDB
- Exposed Cassandra
- Exposed OracleDB
