### PR TITLE
Deprecate exposed-bgp check by a Nuclei template

### DIFF
--- a/cmd/vulcan-nuclei/templates/network/detection/bgp-detect.yaml
+++ b/cmd/vulcan-nuclei/templates/network/detection/bgp-detect.yaml
@@ -1,0 +1,42 @@
+id: bgp-detect
+
+info:
+  name: BGP Detection
+  author: danfaizer
+  severity: info
+  description: |
+    The remote host is running BGP, a popular routing protocol. This indicates that the remote host is probably a network router.
+  reference:
+    - https://www.acunetix.com/vulnerabilities/network/vulnerability/bgp-detection/
+    - https://www.tenable.com/plugins/nessus/11907
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
+  metadata:
+    max-request: 1
+    shodan-query: product:"BGP"
+  tags: network,bgp
+
+tcp:
+  - inputs:
+      - data: FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF001D010400FFFF0000B4C0
+        type: hex
+        # Source: https://www.rfc-editor.org/rfc/rfc4271.html#section-4.2
+        # FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF represents the 16-byte marker field.
+        # 001D is the total length of the BGP message, including the 19 bytes of the header and the optional parameters.
+        # 01 is the BGP message type, which is OPEN (1).
+        # 04 represents the BGP version, which is BGP-4.
+        # FFFF represents the Autonomous System Number (ASN) in hexadecimal format.
+        # 0000 represents the Hold Time.
+        # B4C0 represents the BGP Identifier, usually an IP address in hexadecimal format.
+
+    host:
+      - "{{Hostname}}"
+      - "{{Host}}:179"
+
+    read-size: 16
+    matchers:
+      - type: word
+        encoding: hex
+        words:
+          - "ffffffffffffffffffffffffffffffff"

--- a/cmd/vulcan-nuclei/tests/bgp.bash
+++ b/cmd/vulcan-nuclei/tests/bgp.bash
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 Adevinta
+
+echo -n -e \\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff | nc -l 179


### PR DESCRIPTION
The goal of this PR is deprecate [vulcan-exposed-bgp](https://github.com/adevinta/vulcan-checks/tree/master/cmd/vulcan-exposed-bgp) check in favour of vulcan-nuclei check by providing custom Nuclei template.

**Templates added:**
- BGP Detect

**Test the template**:
```
# Nuclei binary is required.

bash ./cmd/vulcan-nuclei/tests/bgp.bash &; \
nuclei \
   -t ./cmd/vulcan-nuclei/templates/network/detection/bgp-detect.yaml \
   -u localhost
```