### PR TITLE
Remove '--chown' from COPY instruction, as user no longer exists

### DIFF
--- a/cmd/vulcan-gitleaks/Dockerfile
+++ b/cmd/vulcan-gitleaks/Dockerfile
@@ -11,6 +11,6 @@ ENTRYPOINT ["/usr/bin/env"]
 
 # Install check
 ARG TARGETOS TARGETARCH
-COPY --chown=gitleaks ${TARGETOS}/${TARGETARCH}/vulcan-gitleaks /
+COPY ${TARGETOS}/${TARGETARCH}/vulcan-gitleaks /
 
 CMD ["/vulcan-gitleaks"]

--- a/cmd/vulcan-gitleaks/Dockerfile
+++ b/cmd/vulcan-gitleaks/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright 2019 Adevinta
 
-FROM zricethezav/gitleaks
+FROM zricethezav/gitleaks:v8.18.2
 
 # Override base label with 🔑 not supported by artifactory.
 LABEL org.opencontainers.image.description="Protect and discover secrets using Gitleaks"


### PR DESCRIPTION
The user 'gitleaks' was removed in this commit upstream: https://github.com/gitleaks/gitleaks/commit/ac4b5146b0f112df989b4374abb2b12799e37cba

When building this check now, it will fail with the error:
```
unable to convert uid/gid chown string to host mapping
```
Removing this argument pointing to a user that does not exists should fix the issue.