### PR TITLE
Update trivy-check Dockerfile [ change container registry source for images ] 

### DIFF
--- a/cmd/vulcan-trivy/Dockerfile
+++ b/cmd/vulcan-trivy/Dockerfile
@@ -4,8 +4,9 @@ FROM aquasec/trivy:0.55.1
 
 # Required for scanning RHEL/CentOS images
 RUN apk add --no-cache rpm && \
-    trivy --quiet image --download-db-only && \
-    trivy --quiet image --download-java-db-only
+    trivy --quiet image --download-db-only --db-repository public.ecr.aws/aquasecurity/trivy-db && \
+    trivy --quiet image --download-java-db-only  --java-db-repository public.ecr.aws/aquasecurity/trivy-java-db
+
 
 # Skip as it's time consuming to unzip and increases the size of the container (not the image)
 # RUN find /root/.cache -name "*.db" -print -exec gzip {} \;


### PR DESCRIPTION
change repos to use AWS ecr aqauasecurity, because ghcr needs authented to download db and java-db containers