### PR TITLE
Include lottie-backdoor nuclei template as pre

### DIFF
--- a/cmd/vulcan-nuclei/templates/http/vulnerabilities/backdoor/lottie-backdor-pre.yaml
+++ b/cmd/vulcan-nuclei/templates/http/vulnerabilities/backdoor/lottie-backdor-pre.yaml
@@ -1,0 +1,27 @@
+id: lottie-backdoor-pre
+
+info:
+  name: Lottie Player - Backdoor PRE
+  author: nagli-wiz
+  severity: critical
+  description: |
+    Detectes vulnerable compormised version of lottie-player JS Library that were compormised with a Web3 wallet pop-up backdoor.
+  reference:
+    - https://github.com/LottieFiles/lottie-player/issues/254
+    - https://x.com/galnagli/status/1851779972639363076
+  tags: cdn,lottie-player,backdoor,malware
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    redirects: true
+    max-redirects: 1
+
+    matchers:
+      - type: word
+        words:
+          - 'lottie-player@2.0.5'
+          - 'lottie-player@2.0.6'
+          - 'lottie-player@2.0.7'


### PR DESCRIPTION
The template is waiting to be merged https://github.com/projectdiscovery/nuclei-templates/pull/11118
Changed the name to lottie-backdoor-pre to not shadow the upstream when is released.