### PR TITLE
Remove pull_request trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ name: Release
 
 on:
   push:
-  pull_request:
   workflow_dispatch:
     inputs:
       force_build:


### PR DESCRIPTION
All the dependabot builds were failing because the DKR_PASSWORD secret was not available. I fixed this by adding the secret as a DEPENDABOT secret.

With that setup in place we don't need the pull_request event as right now we are not accepting PR other than dependabot ones (and dependabot PRs triggers a push event). So we can save resources and time.

- A pr from a team member or dependabot will generate a push.
- A pr from others won't have access to the DKR_PASSWORD and would fail.

Other better solution would be to design the action to be able to build everything without pushing.
It would be important to keep the whole build process on all the architectures -as there could be issues based on the architecture- but  docker buildx doesn't allow to just build without pushing.

 
