### PR TITLE
Add vulcan-repository-sctrl check

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Currently there's no vendoring provided for this project.
 * **vulcan-nuclei** - Runs [Nuclei](https://github.com/projectdiscovery/nuclei) scanner tool with selected [templates](https://github.com/projectdiscovery/nuclei-templates/)
 * **vulcan-prowler** - Checks compliance against CIS AWS Foundations Benchmark
 * **vulcan-results-load-test** - Internal testing check, not for production
+* **vulcan-repository-sctrl** - Checks whether a Git repository implements security controls.
 * **vulcan-retirejs** - Checks for vulnerabilities in JS frontend dependencies
 * **vulcan-semgrep** - Runs [Semgrep](https://github.com/returntocorp/semgrep) scanner tool for detect security issues in code
 * **vulcan-sleep** - Internal testing check, not for production

--- a/cmd/vulcan-repository-sctrl/.gitignore
+++ b/cmd/vulcan-repository-sctrl/.gitignore
@@ -1,0 +1,1 @@
+vulcan-repository-sctrl

--- a/cmd/vulcan-repository-sctrl/Dockerfile
+++ b/cmd/vulcan-repository-sctrl/Dockerfile
@@ -1,0 +1,14 @@
+# Copyright 2024 Adevinta
+
+FROM semgrep/semgrep:1.97.0-nonroot
+
+# Override entrypoint
+ENTRYPOINT ["/usr/bin/env"]
+
+# Install check
+ARG TARGETOS
+ARG TARGETARCH
+COPY ${TARGETOS}/${TARGETARCH}/vulcan-repository-sctrl /
+COPY custom-rules /custom-rules
+
+CMD ["/vulcan-repository-sctrl"]

--- a/cmd/vulcan-repository-sctrl/README.md
+++ b/cmd/vulcan-repository-sctrl/README.md
@@ -1,0 +1,5 @@
+# vulcan-repository-sctrl
+
+Checks if a code repository has security controls in place.
+
+Based on [Semgrep](https://github.com/returntocorp/semgrep)

--- a/cmd/vulcan-repository-sctrl/custom-rules/repository-with-security-control.yaml
+++ b/cmd/vulcan-repository-sctrl/custom-rules/repository-with-security-control.yaml
@@ -1,0 +1,100 @@
+rules:
+  - id: repository-with-lava-scan
+    message: 'Action using lava scan binary'
+    severity: INFO
+    languages:
+      - yaml
+    paths:
+      include:
+        - ".github/**/*.yaml"
+        - ".github/**/*.yml"
+    patterns:
+      - pattern-regex: 'lava scan'
+  - id: repository-with-lava-action
+    message: 'Action running Lava'
+    severity: INFO
+    languages:
+      - yaml
+    paths:
+      include:
+        - ".github/**/*.yaml"
+        - ".github/**/*.yml"
+    patterns:
+      - patterns:
+          - pattern: |
+              ...
+              uses: "$USES"
+          - metavariable-pattern:
+              metavariable: $USES
+              language: generic
+              pattern-either:
+                - pattern: lava-internal-action
+                - pattern: lava-action
+  - id: repository-with-sonarqube-action
+    message: 'Action running Sonarqube'
+    severity: INFO
+    languages:
+      - yaml
+    paths:
+      include:
+        - ".github/**/*.yaml"
+        - ".github/**/*.yml"
+    patterns:
+      - pattern: |
+          ...
+          uses: "$USES"
+      - metavariable-pattern:
+          metavariable: $USES
+          language: generic
+          pattern: code-quality-action
+  - id: repository-with-trivy-action
+    message: 'Action running Trivy'
+    severity: INFO
+    languages:
+      - yaml
+    paths:
+      include:
+        - ".github/**/*.yaml"
+        - ".github/**/*.yml"
+    patterns:
+      - pattern: |
+          ...
+          uses: "$USES"
+      - metavariable-pattern:
+          metavariable: $USES
+          language: generic
+          pattern: trivy-action
+  - id: repository-with-snyk-action
+    message: 'Action running Snyk'
+    severity: INFO
+    languages:
+      - yaml
+    paths:
+      include:
+        - ".github/**/*.yaml"
+        - ".github/**/*.yml"
+    patterns:
+      - pattern: |
+          ...
+          uses: "$USES"
+      - metavariable-pattern:
+          metavariable: $USES
+          language: generic
+          pattern: snyk/actions
+  - id: repository-with-govulncheck
+    message: 'Action running Govulncheck'
+    severity: INFO
+    languages:
+      - yaml
+    paths:
+      include:
+        - ".github/**/*.yaml"
+        - ".github/**/*.yml"
+    patterns:
+      - pattern: |
+          ...
+          uses: "$USES"
+      - metavariable-pattern:
+          metavariable: $USES
+          language: generic
+          pattern: govulncheck-action

--- a/cmd/vulcan-repository-sctrl/github.go
+++ b/cmd/vulcan-repository-sctrl/github.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2024 Adevinta
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// GitHubAPI defines the default public GitHub base URL.
+	GitHubAPI = "https://api.github.com"
+
+	// GitHubEntepriseAPIPath defines the default GitHub Enterprise API path.
+	GitHubEntepriseAPIPath = "/api/v3"
+
+	// DefaultMaxRetries defines the default number of retries for the HTTP request.
+	DefaultMaxRetries = 3
+
+	// DefaultBackoffDuration defines the default backoff duration for the HTTP request.
+	DefaultBackoffDuration = 5 * time.Second
+)
+
+// RSA represents the repository security and analysis information from the GitHub API.
+type RSA struct {
+	SecurityAndAnalysis struct {
+		SecretScanning struct {
+			Status string `json:"status"`
+		} `json:"secret_scanning"`
+		SecretScanningPushProtection struct {
+			Status string `json:"status"`
+		} `json:"secret_scanning_push_protection"`
+		DependabotSecurityUpdates struct {
+			Status string `json:"status"`
+		} `json:"dependabot_security_updates"`
+		SecretScanningNonProviderPatterns struct {
+			Status string `json:"status"`
+		} `json:"secret_scanning_non_provider_patterns"`
+		SecretScanningValidityChecks struct {
+			Status string `json:"status"`
+		} `json:"secret_scanning_validity_checks"`
+	} `json:"security_and_analysis"`
+}
+
+func checkDependabot(ctx context.Context, logger *logrus.Entry, target string) ([]map[string]string, error) {
+	findingRows := []map[string]string{}
+
+	// Get the repository security information.
+	rsa, err := getRepoSecurityWithRetry(ctx, target, DefaultMaxRetries, DefaultBackoffDuration)
+	if err != nil {
+		return findingRows, err
+	}
+	logger.WithField("security_and_analysis", rsa).Info("repository security and analysis")
+
+	// If the token does not have access to the repository security settings, return an error.
+	if rsa.SecurityAndAnalysis.DependabotSecurityUpdates.Status == "" {
+		return findingRows, fmt.Errorf("unable to obtain repository security information")
+	}
+
+	// Check if Dependabot security updates are enabled.
+	if rsa.SecurityAndAnalysis.DependabotSecurityUpdates.Status != "enabled" {
+		return findingRows, nil
+	}
+
+	link := strings.TrimSuffix(target, ".git") + "/settings/security_analysis"
+	row := map[string]string{
+		"Control": "Dependabot is enabled",
+		"Link":    fmt.Sprintf("(Link)[%s]", link),
+	}
+	findingRows = append(findingRows, row)
+
+	return findingRows, nil
+}
+
+func getRepoSecurityWithRetry(ctx context.Context, target string, maxRetries int, backoff time.Duration) (RSA, error) {
+	var err error
+	var rsa RSA
+	var statusCode int
+
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		rsa, statusCode, err = getRepoSecurity(ctx, target)
+		if err == nil {
+			return rsa, nil
+		}
+		if !strings.HasPrefix(err.Error(), "unexpected status code") {
+			return rsa, err
+		}
+
+		if statusCode >= 500 || statusCode == 429 {
+			time.Sleep(backoff)
+			backoff *= 2
+			continue
+		}
+		break
+	}
+
+	return rsa, fmt.Errorf("failed after %d attempts with error: %w", maxRetries, err)
+}
+
+func getRepoSecurity(ctx context.Context, target string) (RSA, int, error) {
+	var rsa RSA
+	targetURL, err := url.Parse(target)
+	if err != nil {
+		return rsa, 0, fmt.Errorf("unable to parse target as URL: %w", err)
+	}
+
+	targetURL.Path = strings.TrimSuffix(targetURL.Path, ".git")
+	splitPath := strings.Split(targetURL.Path, "/")
+	org, repo := splitPath[1], splitPath[2]
+
+	var url, token string
+	switch {
+	// Public GitHub.
+	case targetURL.Host == "github.com":
+		url = fmt.Sprintf("%s/repos/%s/%s", GitHubAPI, org, repo)
+		token = os.Getenv("GITHUB_API_TOKEN")
+	// Private GitHub Enterprise.
+	case strings.HasPrefix(target, os.Getenv("GITHUB_ENTERPRISE_ENDPOINT")):
+		url = fmt.Sprintf("%s://%s%s/repos/%s/%s", targetURL.Scheme, targetURL.Host, GitHubEntepriseAPIPath, org, repo)
+		token = os.Getenv("GITHUB_ENTERPRISE_TOKEN")
+	default:
+		return rsa, 0, fmt.Errorf("unsupported code repository URL: %s", target)
+	}
+
+	client := &http.Client{}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return rsa, 0, err
+	}
+
+	req.Header.Set("Accept", "application/vnd.github+json")
+	if token != "" {
+		req.Header.Set("Authorization", "token "+token)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return rsa, resp.StatusCode, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return rsa, resp.StatusCode, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return rsa, resp.StatusCode, fmt.Errorf("failed to read response body: %w", err)
+	}
+	if err := json.Unmarshal(body, &rsa); err != nil {
+		return rsa, resp.StatusCode, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	return rsa, resp.StatusCode, nil
+}

--- a/cmd/vulcan-repository-sctrl/local.toml.example
+++ b/cmd/vulcan-repository-sctrl/local.toml.example
@@ -1,0 +1,11 @@
+[Check]
+Target = "https://github.com/adevinta/vulcan-checks.git"
+AssetType = "GitRepository"
+# Options = '{"depth": 1, "branch":"", "rule_config_path":""}'
+
+#[RequiredVars]
+#GITHUB_ENTERPRISE_ENDPOINT = "THE_ENDPOINT"
+#GITHUB_ENTERPRISE_TOKEN = "THE_TOKEN"
+
+#[Log]
+#LogLevel = "DEBUG"

--- a/cmd/vulcan-repository-sctrl/main.go
+++ b/cmd/vulcan-repository-sctrl/main.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2024 Adevinta
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"time"
+
+	check "github.com/adevinta/vulcan-check-sdk"
+	"github.com/adevinta/vulcan-check-sdk/helpers"
+	checkstate "github.com/adevinta/vulcan-check-sdk/state"
+	report "github.com/adevinta/vulcan-report"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	DefaultDepth = 1
+	checkName    = "vulcan-repository-sctrl"
+)
+
+var (
+	missingSecurityControls = report.Vulnerability{
+		CWEID:         693,
+		Summary:       "Repository missing security controls",
+		ImpactDetails: "A repository lacking security controls can lead to expose sensitive information, enable unauthorized access, and other security risks.",
+		Score:         report.SeverityThresholdMedium,
+		Recommendations: []string{
+			"Add a security scanner to your CI/CD pipeline to detect security issues in your codebase.",
+			"If you don't have any default scanner, consider using Lava action in your CI/CD pipeline.",
+		},
+		References: []string{
+			"https://github.mpi-internal.com/adevinta/lava-action",
+			"https://github.mpi-internal.com/spt-security/lava-internal-action",
+		},
+		Labels: []string{"potential", "security-control", "repository"},
+	}
+
+	securityControlFound = report.Vulnerability{
+		Summary: "Security control detected in repository",
+		Score:   report.SeverityThresholdNone,
+		Labels:  []string{"informational", "security-control", "repository"},
+		Resources: []report.ResourcesGroup{
+			{
+				Name: "Security Controls",
+				Header: []string{
+					"Control",
+					"Path",
+					"Link",
+				},
+				Rows: []map[string]string{},
+			},
+		},
+	}
+)
+
+type options struct {
+	Depth          int    `json:"depth"`
+	Branch         string `json:"branch"`
+	RuleConfigPath string `json:"rule_config_path"`
+	Timeout        int    `json:"timeout"`
+}
+
+func main() {
+	run := func(ctx context.Context, target, assetType, optJSON string, state checkstate.State) error {
+		var err error
+		logger := check.NewCheckLogFromContext(ctx, checkName)
+		if target == "" {
+			return errors.New("check target missing")
+		}
+
+		logger = logger.WithFields(logrus.Fields{
+			"asset_type": assetType,
+		})
+
+		opt := options{}
+		if optJSON != "" {
+			if err := json.Unmarshal([]byte(optJSON), &opt); err != nil {
+				return err
+			}
+		}
+		if opt.Depth == 0 {
+			opt.Depth = DefaultDepth
+		}
+
+		logger.WithFields(logrus.Fields{"options": opt}).Debug("using options")
+
+		repoPath, repoBranch, err := helpers.CloneGitRepositoryContext(ctx, target, opt.Branch, opt.Depth)
+		if err != nil {
+			return err
+		}
+		defer os.RemoveAll(repoPath)
+
+		v := securityControlFound
+		v.AffectedResource = target
+
+		// Run semgrep.
+		logger.Info("running semgrep")
+		semgrepTS := time.Now().Unix()
+		r, err := runSemgrep(ctx, logger, opt.Timeout, opt.RuleConfigPath, repoPath)
+		if err != nil {
+			return err
+		}
+		semgrepFindingResources := semgrepFindings(logger, r, target, repoPath, repoBranch)
+		v.Resources[0].Rows = append(v.Resources[0].Rows, semgrepFindingResources...)
+		logger.WithField("semgrep_took", time.Since(time.Unix(semgrepTS, 0)).Seconds()).Info("semgrep took")
+
+		// Check for dependabot.
+		logger.Info("checking dependabot")
+		dependabotTS := time.Now().Unix()
+		dependabotResource, err := checkDependabot(ctx, logger, target)
+		if err != nil {
+			logger.WithError(err).Error("could not get repository security information")
+			if len(v.Resources[0].Rows) > 0 {
+				logger.Warn("dependabot check failed, but skipping error because other security controls were found")
+			} else {
+				return err
+			}
+		}
+		v.Resources[0].Rows = append(v.Resources[0].Rows, dependabotResource...)
+		logger.WithField("dependabot_took", time.Since(time.Unix(dependabotTS, 0)).Seconds()).Info("dependabot took")
+
+		// No security controls found. Reporting missing security controls vulnerability.
+		if len(v.Resources[0].Rows) == 0 {
+			v = missingSecurityControls
+			v.AffectedResource = target
+		}
+
+		state.AddVulnerabilities(v)
+		return nil
+	}
+
+	c := check.NewCheckFromHandler(checkName, run)
+	c.RunAndServe()
+}

--- a/cmd/vulcan-repository-sctrl/manifest.toml
+++ b/cmd/vulcan-repository-sctrl/manifest.toml
@@ -1,0 +1,5 @@
+Description = "Report wether a GitHub repository has a security control in place"
+Timeout = 3600 # 1 hour
+AssetTypes = ["GitRepository"]
+RequiredVars = ["GITHUB_ENTERPRISE_ENDPOINT", "GITHUB_ENTERPRISE_TOKEN"]
+Options = '{"depth": 1, "branch":"", "timeout":0, "rule_config_path":""}'

--- a/cmd/vulcan-repository-sctrl/semgrep.go
+++ b/cmd/vulcan-repository-sctrl/semgrep.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2024 Adevinta
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/adevinta/vulcan-check-sdk/helpers/command"
+	"github.com/sirupsen/logrus"
+)
+
+const Cmd = `semgrep`
+
+const DefaultRuleConfigPath = `/custom-rules/repository-with-security-control.yaml`
+
+// NOTE: keep this const block separated to not mess with the iota generated
+// values.
+const (
+	/*
+		Semgrep exit codes from https://semgrep.dev/docs/cli-usage/#exit-codes:
+			0: Semgrep ran successfully and found no errors (or did find errors, but the --error flag is not set)
+			1: Semgrep ran successfully and found issues in your code (and the --error flag is set)
+			2: Semgrep failed
+			3: Semgrep failed to parse a file in the specified language
+			4: Semgrep encountered an invalid pattern
+			5: Semgrep config is not valid yaml
+			6: Rule with pattern-where-python found but --dangerously-allow-arbitrary-code-execution-from-rules was not set. See --dangerously-allow-arbitrary-code-execution-from-rules.
+			7: All rules in config are invalid. If semgrep is run with --strict then this exit code is returned when any rule in the configs are invalid.
+			8: Semgrep does not understand specified language
+			9: Semgrep exceeded match timeout. See --timeout
+			10: Semgrep exceeded max memory while matching. See --max-memory.
+			11: Semgrep encountered a lexical error when running rule on a file.
+	*/
+	SemgrepStatusOK = iota // This should be always 0.
+	SemgrepStatusOKWithIssues
+	SemgrepStatusFailed
+	SemgrepStatusFailedParsingFile
+	SemgrepStatusFailedInvalidPattern
+	SemgrepStatusFailedConfig
+	SemgrepStatusFailedUnsafe
+	SemgrepStatusFailedInvalidRules
+	SemgrepStatusFailedUnknownLanguage
+	SemgrepStatusFailedTimeout
+	SemgrepStatusFailedMaxMemory
+	SemgrepStatusFailedLexical
+)
+
+var AlwaysExcluded = []string{"*swagger*.js"}
+
+// SemgrepOutput and Result represent the output information from the semgrep
+// command.  Non-used fields have been intentionally ommitted.
+type SemgrepOutput struct {
+	Results []Result      `json:"results"`
+	Errors  []interface{} `json:"errors"`
+}
+type Result struct {
+	CheckID string `json:"check_id"`
+	Path    string `json:"path"`
+	Start   struct {
+		Line int `json:"line"`
+	} `json:"start"`
+	Extra struct {
+		Message  string `json:"message"`
+		Metavars struct {
+			AbstractContent string `json:"abstract_content"`
+		} `json:"metavars"`
+	} `json:"extra,omitempty"`
+}
+
+func semgrepFindings(logger *logrus.Entry, r SemgrepOutput, target, repo, branch string) []map[string]string {
+	findingRows := []map[string]string{}
+	if len(r.Results) < 1 {
+		logger.Info("no security controls found by semgrep")
+		return findingRows
+	}
+
+	logger.WithFields(logrus.Fields{"num_results": len(r.Results)}).Info("security controls found. Processing results")
+
+	for _, result := range r.Results {
+		filepath := strings.TrimPrefix(result.Path, fmt.Sprintf("%s/", repo))
+		path := fmt.Sprintf("%s:%d", filepath, result.Start.Line)
+		link := strings.TrimSuffix(target, ".git") + "/blob/" + branch + "/" + filepath + "#L" + fmt.Sprint(result.Start.Line)
+		row := map[string]string{
+			"Control": result.Extra.Message,
+			"Path":    path,
+			"Link":    fmt.Sprintf("(Link)[%s]", link),
+		}
+		findingRows = append(findingRows, row)
+	}
+
+	return findingRows
+}
+
+func runSemgrep(ctx context.Context, logger *logrus.Entry, timeout int, ruleConfigPath string, dir string) (SemgrepOutput, error) {
+	if ruleConfigPath == "" {
+		ruleConfigPath = DefaultRuleConfigPath
+	}
+	var params = []string{"--json", "--config", ruleConfigPath}
+	params = append(params, "--timeout", strconv.Itoa(timeout))
+	params = append(params, dir)
+
+	var report SemgrepOutput
+	exitCode, err := command.ExecuteAndParseJSON(ctx, logger, &report, Cmd, params...)
+	if err != nil {
+		return report, err
+	}
+
+	logger.WithFields(logrus.Fields{"exit_code": exitCode, "report": report}).Debug("semgrep command finished")
+
+	switch exitCode {
+	case SemgrepStatusOK, SemgrepStatusOKWithIssues:
+		return report, nil
+	// Don't fail the check for unsupported languages.
+	case SemgrepStatusFailedUnknownLanguage:
+		return report, nil
+	default:
+		err := fmt.Errorf("semgrep scan failed with exit code %d", exitCode)
+		logger.WithError(err).WithFields(logrus.Fields{"errors": report.Errors}).Error("")
+		return report, err
+	}
+}


### PR DESCRIPTION
This PR adds the `vulcan-repository-sctrl` check, which provides insights into whether a Git repository has security controls in place.

The check primarily reports two possible findings:
- **Informational finding**: Security controls detected in the repository.
- **Medium severity finding**: Repository missing security controls.

If security controls are detected in the repository, the check provides a list of these controls in the "check finding resources" table.

Below is an example of how the check's output appears in Lava:

**With** security controls in place:
```
STATUS

- vulcan-repository-sctrl → https://REDACTED: FINISHED

SUMMARY

CRITICAL: 0
HIGH: 0
MEDIUM: 0
LOW: 0
INFO: 1

Number of excluded vulnerabilities not included in the summary table: 0

VULNERABILITIES

=== Security control detected in repository (INFO) ===

TARGET
https://REDACTED

AFFECTED RESOURCE
https://REDACTED

RESOURCES
- Security Controls:
  Control: Action running Lava
  Path: .github/workflows/test-build.yaml:39
  Link: (Link)[https://REDACTED/blob/master/.github/workflows/test-build.yaml#L39]
  Control: Dependabot is enabled
  Path:
  Link: (Link)[https://REDACTED/settings/security_analysis]
```

**Without** security controls in place:
```
STATUS

- vulcan-repository-sctrl → https://REDACTED: FINISHED

SUMMARY

CRITICAL: 0
HIGH: 0
MEDIUM: 1
LOW: 0
INFO: 0

Number of excluded vulnerabilities not included in the summary table: 0

VULNERABILITIES

=== Repository missing security controls (MEDIUM) ===

TARGET
https://REDACTED

AFFECTED RESOURCE
https://REDACTED

IMPACT
A repository lacking security controls can lead to expose sensitive information, enable unauthorized access, and other security risks.

RECOMMENDATIONS
- Add a security scanner to your CI/CD pipeline to detect security issues in your codebase.
- If you don't have any default scanner, consider using Lava action in your CI/CD pipeline.

REFERENCES
- https://github.mpi-internal.com/adevinta/lava-action
- https://github.mpi-internal.com/spt-security/lava-internal-action
```