### PR TITLE
encode the INVENTORY_ENDPOINT variable in base64

### DIFF
--- a/cmd/vulcan-aws-subdomain-takeover/local.toml.example
+++ b/cmd/vulcan-aws-subdomain-takeover/local.toml.example
@@ -5,6 +5,10 @@ AssetType = "AWSAccount"
 [RequiredVars]
 VULCAN_ASSUME_ROLE_ENDPOINT="http://localhost:8080/assume"
 ROLE_NAME="SecurityAuditRole"
-INVENTORY_ENDPOINT="http://localhost:8081/api/publicips/{{.IP}}" # Optional.
-INVENTORY_HEADERS='{"token": "MYSECRETTOKEN", "Content-Type": "application/json"}' # Optional headers.
-INVENTORY_NOTFOUND_BODY='{}' # Optional regex for not found. If empty just rely on the status.
+
+# Optional. A Go template, encoded in base64, that representing and endpoint will be rendered with the IP.
+INVENTORY_ENDPOINT="aHR0cDovL2xvY2FsaG9zdDo4MDgxL2FwaS9wdWJsaWNpcHMve3suSVB9fQ=="
+# Optional headers.
+INVENTORY_HEADERS='{"token": "MYSECRETTOKEN", "Content-Type": "application/json"}'
+# Optional regex for not found. If empty just rely on the status.
+INVENTORY_NOTFOUND_BODY='{}'

--- a/cmd/vulcan-aws-subdomain-takeover/main.go
+++ b/cmd/vulcan-aws-subdomain-takeover/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -95,6 +96,10 @@ func NewScanner(ctx context.Context, logger *logrus.Entry, target string) (Scann
 	var inventory Inventory
 	var headers map[string]string
 	if inventoryEndpoint := os.Getenv("INVENTORY_ENDPOINT"); inventoryEndpoint != "" {
+		decodedEndpoint, err := base64.StdEncoding.DecodeString(inventoryEndpoint)
+		if err != nil {
+			return Scanner{}, fmt.Errorf("decoding INVENTORY_ENDPOINT: %w", err)
+		}
 		if os.Getenv("INVENTORY_HEADERS") != "" {
 			envHeaders := os.Getenv("INVENTORY_HEADERS")
 			if err = json.Unmarshal([]byte(envHeaders), &headers); err != nil {
@@ -107,7 +112,7 @@ func NewScanner(ctx context.Context, logger *logrus.Entry, target string) (Scann
 		}
 
 		inventory, err = NewCloudInventory(
-			inventoryEndpoint,
+			string(decodedEndpoint),
 			headers,
 			inventoryNotFoundBody,
 		)


### PR DESCRIPTION
The curly brackets can cause problems when storing the configuration in some systems as AWS. So, the variable INVENTORY_ENDPOINT, which represents a Go template, will be passed encoded in base64.